### PR TITLE
fix_read_the_docs_build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-Sphinx==1.8.3
-sphinx-rtd-theme==0.4.2
-recommonmark==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ requests==2.19.1
 requests-toolbelt==0.8.0
 contextlib2==0.5.5
 pytest==3.7.2
+Sphinx==1.8.3
+sphinx-rtd-theme==0.4.2
+recommonmark==0.5.0

--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -3,8 +3,8 @@
 
 import contextlib2
 
-import stardog.content_types as content_types
-import stardog.http.admin as http_admin
+from . import content_types as content_types
+from .http import admin as http_admin
 
 
 class Admin(object):

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -4,9 +4,9 @@
 import contextlib
 import distutils.util
 
-import stardog.content_types as content_types
-import stardog.exceptions as exceptions
-import stardog.http.connection as http_connection
+from . import content_types as content_types
+from . import exceptions as exceptions
+from .http import connection as http_connection
 
 
 class Connection(object):

--- a/stardog/content.py
+++ b/stardog/content.py
@@ -5,7 +5,7 @@ import os
 
 import requests
 
-import stardog.content_types as content_types
+from . import content_types as content_types
 
 
 class Content(object):

--- a/stardog/http/admin.py
+++ b/stardog/http/admin.py
@@ -1,10 +1,10 @@
 import json
 
-import stardog.http.client as http_client
-import stardog.http.database as http_database
-import stardog.http.role as http_role
-import stardog.http.user as http_user
-import stardog.http.virtual_graphs as http_virtual_graphs
+from . import client as http_client
+from . import database as http_database
+from . import role as http_role
+from . import user as http_user
+from . import virtual_graphs as http_virtual_graphs
 
 
 class Admin(object):

--- a/stardog/http/client.py
+++ b/stardog/http/client.py
@@ -1,7 +1,7 @@
 import requests
 import requests_toolbelt.multipart as multipart
 
-import stardog.exceptions as exceptions
+from .. import exceptions as exceptions
 
 
 class Client(object):

--- a/stardog/http/connection.py
+++ b/stardog/http/connection.py
@@ -1,11 +1,11 @@
 import distutils.util
 
-import stardog.content_types as content_types
-import stardog.http.client as http_client
-import stardog.http.docs as http_docs
-import stardog.http.graphql as http_graphql
-import stardog.http.icv as http_icv
-import stardog.http.vcs as http_vcs
+from .. import content_types as content_types
+from . import client as http_client
+from . import docs as http_docs
+from . import graphql as http_graphql
+from . import icv as http_icv
+from . import vcs as http_vcs
 
 
 class Connection(object):

--- a/stardog/http/graphql.py
+++ b/stardog/http/graphql.py
@@ -1,4 +1,4 @@
-import stardog.exceptions as exceptions
+from .. import exceptions as exceptions
 
 
 class GraphQL(object):

--- a/stardog/http/role.py
+++ b/stardog/http/role.py
@@ -1,4 +1,4 @@
-import stardog.http.user as http_user
+from . import user as http_user
 
 
 class Role(object):

--- a/stardog/http/user.py
+++ b/stardog/http/user.py
@@ -1,4 +1,4 @@
-import stardog.http.role as role
+from . import role as role
 
 
 class User(object):

--- a/stardog/http/vcs.py
+++ b/stardog/http/vcs.py
@@ -1,4 +1,4 @@
-import stardog.content_types as content_types
+from .. import content_types as content_types
 
 
 class VCS(object):

--- a/stardog/http/virtual_graphs.py
+++ b/stardog/http/virtual_graphs.py
@@ -1,4 +1,4 @@
-import stardog.content_types as content_types
+from .. import content_types as content_types
 
 
 class VirtualGraph(object):


### PR DESCRIPTION
The autodocs were not building properly inside Read the Docs because it was unable to import the required modules. I switched from absolute to relative imports and that fixed it.

Closes #19 