### PR TITLE
cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,8 @@ jobs:
 
       - run:
           name: Start containers and run tests
-          no_output_timeout: 10m
+          no_output_timeout: 15m
           command: |
             set -x
             docker-compose up --exit-code-from tests
-
-
 

--- a/.env
+++ b/.env
@@ -1,7 +1,28 @@
 # Stardog version tag
 STARDOG_TAG=latest
+STARDOG_USER=admin
+STARDOG_PASS=admin
 
 # Zookeeper version tag
 ZOO_TAG=3.4
+
+# HAProxy
+HAPROXY_TAG=latest
+
+
+# Host / Container names
+# CircleCI does not resolve hostnames defined in docker-compose easily (i.e using the hostname field).
+# Working around this using the container name as hostnames.
+# https://www.docker.com/blog/docker-1-10/
+STARDOG_HOSTNAME_NODE_1=stardog-1
+STARDOG_HOSTNAME_NODE_2=stardog-2
+STARDOG_HOSTNAME_STANDBY=stardog-standby
+STARDOG_HOSTNAME_CACHE=stardog-cache
+STARDOG_LB=sd-lb
+
+# Tests vars
+SSH_USER=stardog
+SSH_PASS=stardogpw
+
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,23 +3,87 @@
 # For this reason, we are creating specific dockerfiles, and building the images from them, copying the files in the images
 # instead of mounting them.
 
-
 version: "3.3"
 services:
+  zoo1:
+    image: zookeeper:${ZOO_TAG}
+    container_name: zkn1
+    environment:
+        ZOO_MY_ID: 1
+        ZOO_SERVERS: server.1=0.0.0.0:2888:3888
+
   sd1:
     build:
       context: dockerfiles/
       dockerfile: dockerfile-stardog
-    container_name: pystardog_stardog
+      args:
+        - TAG=${STARDOG_TAG}
+        - NODE_TYPE=node
+        - SSH_USER=${SSH_USER}
+        - SSH_PASS=${SSH_PASS}
+    container_name: ${STARDOG_HOSTNAME_NODE_1}
     entrypoint: ["/bin/bash", "-c"]
     command: ["/var/start.sh"]
+    depends_on:
+      - zoo1
+
+  sd2:
+    build:
+      context: dockerfiles/
+      dockerfile: dockerfile-stardog
+      args:
+          - TAG=${STARDOG_TAG}
+          - NODE_TYPE=node
+          - SSH_USER=${SSH_USER}
+          - SSH_PASS=${SSH_PASS}
+    container_name: ${STARDOG_HOSTNAME_NODE_2}
+    entrypoint: ["/bin/bash", "-c"]
+    command: ["/var/start.sh"]
+    depends_on:
+      - zoo1
+
+  sdstandby:
+    build:
+      context: dockerfiles/
+      dockerfile: dockerfile-stardog
+      args:
+        - TAG=${STARDOG_TAG}
+        - NODE_TYPE=standby
+        - SSH_USER=${SSH_USER}
+        - SSH_PASS=${SSH_PASS}
+    container_name: ${STARDOG_HOSTNAME_STANDBY}
+    entrypoint: ["/bin/bash", "-c"]
+    command: ["/var/start-standby.sh"]
+    depends_on:
+      - zoo1
 
   sdcache1:
     build:
       context: dockerfiles/
       dockerfile: dockerfile-stardog
+      args:
+        - TAG=${STARDOG_TAG}
+        - NODE_TYPE=cache
+        - SSH_USER=${SSH_USER}
+        - SSH_PASS=${SSH_PASS}
     # underscores not allowed for cache target hostnames
-    container_name: pystardog-cache-1
+    entrypoint: ["/bin/bash", "-c"]
+    command: ["/var/start.sh"]
+    container_name: ${STARDOG_HOSTNAME_CACHE}
+    depends_on:
+      - zoo1
+
+  sdlb:
+    build:
+      context: dockerfiles/
+      dockerfile: dockerfile-haproxy
+      args:
+        - TAG=${HAPROXY_TAG}
+    container_name: ${STARDOG_LB}
+    depends_on:
+      - zoo1
+      - sd1
+      - sd2
 
   tests:
     build:
@@ -28,6 +92,16 @@ services:
     entrypoint: /bin/bash -c
     command: ["./utils/run_tests.sh"]
     container_name: pystardog_tests
+    environment:
+      - SSH_USER=${SSH_USER}
+      - SSH_PASS=${SSH_PASS}
+      - STARDOG_HOSTNAME_NODE_1=${STARDOG_HOSTNAME_NODE_1}
+      - STARDOG_HOSTNAME_CACHE=${STARDOG_HOSTNAME_CACHE}
+      - STARDOG_HOSTNAME_STANDBY=${STARDOG_HOSTNAME_STANDBY}
+      - STARDOG_LB=${STARDOG_LB}
+      - STARDOG_USER=${STARDOG_USER}
+      - STARDOG_PASS=${STARDOG_PASS}
+
 
   # two mysql servers are used instead of one so we can simulate multiple datasources.
   mysql-music:

--- a/dockerfiles/dockerfile-haproxy
+++ b/dockerfiles/dockerfile-haproxy
@@ -1,0 +1,5 @@
+ARG TAG
+
+FROM haproxy:$TAG
+
+COPY haproxy.cfg /usr/local/etc/haproxy/

--- a/dockerfiles/dockerfile-python
+++ b/dockerfiles/dockerfile-python
@@ -1,6 +1,6 @@
 FROM python
 
-RUN apt-get update && apt-get install sshpass
+RUN apt-get update && apt-get install sshpass jq -y
 
 COPY . /var/pystardog
 

--- a/dockerfiles/dockerfile-stardog
+++ b/dockerfiles/dockerfile-stardog
@@ -10,13 +10,16 @@ RUN wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${
 FROM stardog/stardog
 
 ARG NODE_TYPE
+ARG SSH_USER
+ARG SSH_PASS
 
 COPY --from=base /tmp/mysql-connector-java.jar opt/stardog/server/dbms
 COPY stardog-license-key.bin /var/opt/stardog
 COPY start.sh /var/start.sh
+COPY start-standby.sh /var/start-standby.sh
 
 USER root
-RUN yes stardogpw | passwd stardog
+RUN yes $SSH_PASS | passwd $SSH_USER
 RUN yum install openssh-server vim -y
 
 USER stardog
@@ -36,5 +39,7 @@ RUN mkdir ${HOME}/custom_ssh && \
     PidFile ${HOME}/custom_ssh/sshd.pid" > ${HOME}/custom_ssh/sshd_config
 
 
+
+COPY stardog.$NODE_TYPE.properties /var/opt/stardog/stardog.properties
 
 

--- a/dockerfiles/haproxy.cfg
+++ b/dockerfiles/haproxy.cfg
@@ -1,0 +1,60 @@
+global
+    daemon
+    maxconn 256
+
+defaults
+    # you should update these values to something that makes
+    # sense for your use case
+    timeout connect 5s
+    timeout client 1h
+    timeout server 1h
+    mode http
+
+# where HAProxy will listen for connections
+frontend stardog-in
+    option tcpka # keep-alive
+    bind *:5820
+    # the following lines identify any routes with "transaction"
+    # in the path and send them directly to the coordinator, if
+    # haproxy is unable to determine the coordinator all requests
+    # will fall through and be routed via the default_backend
+    acl transaction_route path_sub -i transaction
+    use_backend stardog_coordinator if transaction_route
+    default_backend all_stardogs
+
+# the Stardog coordinator
+backend stardog_coordinator
+    option tcpka
+    # the following line returns 200 for the coordinator node
+    # and 503 for non-coordinators so traffic is only sent
+    # to the coordinator
+    option httpchk GET /admin/cluster/coordinator
+    # the check interval can be increased or decreased depending
+    # on your requirements and use case, if it is imperative that
+    # traffic be routed to the coordinator as quickly as possible
+    # after the coordinator changes, you may wish to reduce this value
+    default-server inter 5s
+    # replace these IP addresses with the corresponding node address
+    # maxconn value can be upgraded if you expect more concurrent
+    # connections
+    server stardog-1 stardog-1:5820 maxconn 64 check
+    server stardog-2 stardog-2:5820 maxconn 64 check
+    #server standby1 standby1:5820 maxconn 64 check
+
+# the Stardog servers
+backend all_stardogs
+    option tcpka # keep-alive
+    balance source
+    hash-type consistent # optional
+    # the following line performs a health check
+    # HAProxy will check that each node accepts connections and
+    # that it's operational within the cluster. Health check
+    # requires that Stardog nodes do not use --no-http option
+    option httpchk GET /admin/healthcheck
+    default-server inter 5s
+    # replace these IP addresses with the corresponding node address
+    # maxconn value can be upgraded if you expect more concurrent
+    # connections
+    server stardog-1 stardog-1:5820 maxconn 64 check
+    server stardog-2 stardog-2:5820 maxconn 64 check
+    #server standby1 standby1:5820 maxconn 64 check

--- a/dockerfiles/stardog.cache.properties
+++ b/dockerfiles/stardog.cache.properties
@@ -1,0 +1,21 @@
+# We disable this file because the cache gets manually registered as part of the tests.
+# Reusing a stardog.node.properties would make it part of a cluster, which is not what we want,
+# as cache nodes are meant to be separate Stardog instances.
+# We leave the default cache properties commented for reference.
+
+# Flag to run this server as a cache target
+# cache.target.enabled=true
+
+# If using the cache target with a cluster we need to tell it where
+# the clusters zookeeper installation is running
+# pack.zookeeper.address=zoo1:2181,zoo2:2181,zoo3:2181
+
+# Flag to automatically register this cache target on startup.  This is
+# only applicable when using a cluster.
+# cache.target.autoregister=false
+# The name to use for this cache target on auto register.  This defaults
+# to the hostname
+# cache.target.name = "mycache"
+
+# would need to change for production
+# pack.zookeeper.auth=admin:admin

--- a/dockerfiles/stardog.node.properties
+++ b/dockerfiles/stardog.node.properties
@@ -1,0 +1,10 @@
+# Flag to enable the cluster, without this flag set, the rest of the properties have no effect
+pack.enabled=true
+# this node's IP address (or hostname) where other Stardog nodes are going to connect
+# this value is optional but if provided it should be unique for each Stardog node
+#pack.node.address=196.69.68.4
+# the connection string for ZooKeeper where cluster state is stored
+pack.zookeeper.address=zoo1:2181
+
+# would need to change for production
+pack.zookeeper.auth=admin:admin

--- a/dockerfiles/stardog.standby.properties
+++ b/dockerfiles/stardog.standby.properties
@@ -1,0 +1,15 @@
+# Flag to enable the cluster, without this flag set, the rest of the properties have no effect
+pack.enabled=true
+# this node's IP address (or hostname) where other Stardog nodes are going to connect
+# this value is optional but if provided it should be unique for each Stardog node
+#pack.node.address=196.69.68.4
+# the connection string for ZooKeeper where cluster state is stored
+pack.zookeeper.address=zoo1:2181
+
+# would need to change for production
+pack.zookeeper.auth=admin:admin
+
+# Make the node a standby node
+# https://docs.stardog.com/cluster/operating-the-cluster/standby-nodes
+pack.standby=true
+pack.standby.node.sync.interval=5m

--- a/dockerfiles/start-standby.sh
+++ b/dockerfiles/start-standby.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+function wait_for_cluster_ready(){
+    (
+    # Wait for stardog to be running
+    COUNT=0
+    set +e
+    while :
+    do
+      if [[ ${COUNT} -gt 50 ]]; then
+          echo "Failed to start Stardog cluster on time"
+          return 1;
+      fi
+      COUNT=$(expr 1 + ${COUNT})
+      sleep 3
+
+      number_of_nodes=$(/opt/stardog/bin/stardog-admin --server  http://sdlb:5820  cluster status | grep Node | wc -l)
+      if [[ $number_of_nodes -eq 2 ]]; then break; fi
+    done
+
+    return 0
+    )
+
+}
+wait_for_cluster_ready
+echo "Main cluster ready, starting standby node"
+/var/start.sh

--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -66,8 +66,6 @@ class Admin(object):
 
     def get_prometheus_metrics(self):
         """
-        :return:  Return metric information from the registry in Prometheus format
-        :rtype: String
         """
         r = self.client.get('/admin/status/prometheus')
         return r.text
@@ -649,68 +647,91 @@ class Admin(object):
         """
         self.client.get('/admin/users/valid')
 
-    #TODO
-    # def cluster_list_standby_nodes(self):
-    #     """
-    #     List standby nodes
-    #     https://stardog-union.github.io/http-docs/#operation/getStandbyNodes
-    #     :return:
-    #     """
+    def cluster_list_standby_nodes(self):
+        """
+        List standby nodes
+        :return: Returns the registry ID for the standby nodes.
+        :rtype: dict
+        """
+        r = self.client.get('/admin/cluster/standby/registry')
+        return r.json()
 
-    #TODO
-    # def cluster_join(self):
-    #     """
-    #     Instruct a standby node to join its cluster as a full node
-    #     https://stardog-union.github.io/http-docs/#operation/standbyJoin
-    #     :return:
-    #     """
+    def cluster_join(self):
+        """
+        Instruct a standby node to join its cluster as a full node
+        """
+        self.client.put('/admin/cluster/standby/join')
 
-    #TODO
-    # def cluster_node_pause_status(self):
-    #     """
-    #     Get the pause status of a standby node
-    #     https://stardog-union.github.io/http-docs/#operation/getPauseState
-    #     :return:
-    #     """
+    def standby_node_pause_status(self):
+        """
+        Get the pause status of a standby node
+        https://stardog-union.github.io/http-docs/#operation/getPauseState
+        :return: Pause status of a standby node, possible values are: "WAITING", "SYNCING", "PAUSING", "PAUSED"
+        :rtype: Dict
+        """
+        r = self.client.get('/admin/cluster/standby/pause')
+        return r.json()
 
-    #TODO
-    # def cluster_node_pause(self):
-    #     """
-    #     Pause/Unpause standby node
-    #     https://stardog-union.github.io/http-docs/#operation/standbyPause
-    #     :return:
-    #     """
+    def standby_node_pause(self, pause):
+        """
+        Pause/Unpause standby node
+        Args:
+          *pause: (boolean): True for pause, False for unpause
+        :return: Returns True if the pause status was modified successfully, false if it failed.
+        :rtype: bool
+        """
+        if pause:
+            r = self.client.put('/admin/cluster/standby/pause?pause=true')
+        else:
+            r = self.client.put('/admin/cluster/standby/pause?pause=false')
+        return r.status_code == 200
 
-    #TODO
-    # def cluster_revoke_standby_access(self):
-    #     """
-    #     Instruct a standby node to leave its cluster
-    #     https://stardog-union.github.io/http-docs/#operation/standbyRevokeAccess
-    #     :return:
-    #     """
 
-    #TODO
-    # def cluster_coordinator_check(self):
-    #     """
-    #     Determine if a specific cluster node is the cluster coordinator
-    #     https://stardog-union.github.io/http-docs/#operation/isCoordinator
-    #     :return:
-    #     """
+    def cluster_revoke_standby_access(self, registry_id):
+        """
+        Instruct a standby node to stop syncing
+        Args:
+          *registry_id: (string): Id of the standby node to stop syncing.
+        """
+        self.client.delete('/admin/cluster/standby/registry/' + registry_id)
 
-    #TODO
+    def cluster_start_readonly(self):
+        """
+        Start read only mode
+        """
+        self.client.put('/admin/cluster/readonly')
+
+    def cluster_stop_readonly(self):
+        """
+        Stops read only mode
+        """
+        self.client.delete('/admin/cluster/readonly')
+
+    def cluster_coordinator_check(self):
+        """
+        Determine if a specific cluster node is the cluster coordinator
+        :return: True if the node is a coordinator, false if not.
+        :rtype: Bool
+        """
+        r = self.client.get('/admin/cluster/coordinator')
+        return r.status_code == 200
+
+    #TODO:
     # def cluster_diagnostics_report(self):
     #     """
     #     Get cluster diagnostics report
     #     https://stardog-union.github.io/http-docs/#operation/generateClusterDiagnosticsReport
     #     :return:
     #     """
+    #     r = self.client.post('/admin/cluster/diagnostics')
+    #     return r
 
     def cluster_status(self):
         """Prints status information for each node
         in the cluster
 
-        Returns:
-            dict: Nodes of the cluster and extra information
+        :return: Nodes of the cluster and extra information
+        :rtype: dict
         """
         r = self.client.get('/admin/cluster/status')
         return r.json()
@@ -719,20 +740,20 @@ class Admin(object):
         """Prints info about the nodes in the Stardog
         Pack cluster.
 
-        Returns:
-            dict: Nodes of the cluster.
+        :return: Nodes of the cluster
+        :rtype: dict
         """
         r = self.client.get('/admin/cluster')
         return r.json()
 
-
-    #TODO
-    # def cluster_shutdown(self):
-    #     """
-    #     Shutdown all nodes
-    #    https://stardog-union.github.io/http-docs/#operation/shutdownAll
-    #     :return:
-    #     """
+    def cluster_shutdown(self):
+        """
+        Shutdown all nodes
+        :return: True if the cluster got shutdown successfully.
+        :rtype: bool
+        """
+        r = self.client.post('/admin/shutdownAll')
+        return r.status_code == 200
 
 
     def cache(self, name):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,11 @@
 import pytest
 import stardog.content as content
 import stardog.content_types as content_types
+import os
 
+STARDOG_HOSTNAME_NODE_1 = os.environ['STARDOG_HOSTNAME_NODE_1']
+STARDOG_HOSTNAME_CACHE = os.environ['STARDOG_HOSTNAME_CACHE']
+STARDOG_HOSTNAME_STANDBY = os.environ['STARDOG_HOSTNAME_STANDBY']
 
 def pytest_addoption(parser):
     parser.addoption("--username", action="store", default="admin")
@@ -36,13 +40,21 @@ def bulkload_content():
 def cache_target_info():
     target_info = {
         'target_name': 'pystardog-test-cache-target',
-        #docker-compose sdcache1 containername
-        'hostname': 'pystardog-cache-1',
+        'hostname': STARDOG_HOSTNAME_CACHE,
         'port': 5820,
         'username': 'admin',
         'password': 'admin'
     }
     return target_info
+
+@pytest.fixture
+def cluster_standby_node_conn_string():
+    standby_conn_string= {
+        'endpoint': f"http://{STARDOG_HOSTNAME_STANDBY}:5820",
+        'username': 'admin',
+        'password': 'admin'
+    }
+    return standby_conn_string
 
 # Java 291 (packed in the Stardog docker image from 7.6.3+) disabled TLS 1.0 and 1.1 which breaks the MySQL connector:
 # https://www.oracle.com/java/technologies/javase/8u291-relnotes.html

--- a/utils/run_tests.sh
+++ b/utils/run_tests.sh
@@ -3,29 +3,38 @@
 function wait_for_start {
     (
     HOST=${1}
-    PORT=${2}
+    STANDBY=${2}
+    PORT=${3}
     # Wait for stardog to be running
-    RC=1
     COUNT=0
     set +e
-    while [[ ${RC} -ne 0 ]];
+    not_ready=true
+    while $not_ready
     do
       if [[ ${COUNT} -gt 50 ]]; then
           echo "Failed to start Stardog cluster on time"
           return 1;
       fi
       COUNT=$(expr 1 + ${COUNT} )
-      sleep 1
-      curl -v  http://${HOST}:${PORT}/admin/healthcheck
+      sleep 5
+
+      # wait for main cluster to be ready
+      number_of_nodes=$(curl -s http://${HOST}:${PORT}/admin/cluster/ -u ${STARDOG_USER}:${STARDOG_PASS} | jq .'nodes | length')
+      echo "number of nodes ready: " $number_of_nodes
+
+      # wait for standby node to be ready. standby nodes needs to wait for main cluster first.
+      curl -s http://${STANDBY}:5820/admin/healthcheck
       RC=$?
+      if [[ $number_of_nodes -eq 2 && $RC -eq 0 ]]; then break; fi
+
+
     done
-    # Give it a second to finish starting up
+    # Give it a second to finish starting up.
     sleep 5
 
     return 0
     )
 }
 
-# depends_on in compose is not enough
-wait_for_start pystardog_stardog 5820
-pytest --endpoint http://pystardog_stardog:5820
+wait_for_start ${STARDOG_LB} ${STARDOG_HOSTNAME_STANDBY} 5820
+pytest --endpoint http://${STARDOG_LB}:5820 -s


### PR DESCRIPTION
Adds cluster functionalities and integration tests for each functionality.
Adds 1 node to the tests to make stardog work as a cluster (so 2 nodes total)
Adds 1 standby node to test standby features (ad the end of the tests it will end up with 3 nodes: 2 main nodes, plus the standby)