### PR TITLE
add http.client.Client with custom session object or explicit proxies

### DIFF
--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -16,7 +16,13 @@ class Connection(object):
     Stardog database
     """
 
-    def __init__(self, database, endpoint=None, username=None, password=None, auth=None):
+    def __init__(self,
+                 database,
+                 endpoint=None,
+                 username=None,
+                 password=None,
+                 auth=None,
+                 session=None):
         """Initializes a connection to a Stardog database.
 
         Args:
@@ -27,12 +33,19 @@ class Connection(object):
           password (str, optional): Password to use in the connection
           auth (requests.auth.AuthBase, optional): requests Authentication object.
             Defaults to `None`
+          session (requests.session.Session, optional): requests Session object.
+            Defaults to `None`
 
         Examples:
           >>> conn = Connection('db', endpoint='http://localhost:9999',
                                 username='admin', password='admin')
         """
-        self.client = client.Client(endpoint, database, username, password, auth=auth)
+        self.client = client.Client(endpoint,
+                                    database,
+                                    username,
+                                    password,
+                                    auth=auth,
+                                    session=session)
         self.transaction = None
 
     def docs(self):

--- a/stardog/http/client.py
+++ b/stardog/http/client.py
@@ -16,6 +16,8 @@ class Client(object):
                  database=None,
                  username=None,
                  password=None,
+                 session=None,
+                 proxies=None,
                  auth=None):
         self.url = endpoint if endpoint else self.DEFAULT_ENDPOINT
 
@@ -26,7 +28,20 @@ class Client(object):
         if database:
             self.url = '{}/{}'.format(self.url, database)
 
-        self.session = requests.Session()
+        if session is None:
+            self.session = requests.Session()
+            if proxies is not None:
+                if isinstance(proxies, dict) and any([key in proxies.keys() for key in ('http', 'https')]):
+                    self.session.proxies.update(proxies)
+                else:
+                    raise TypeError(f"{proxies=} must be a dict of `'scheme': 'scheme://hostname'` item(s).")
+        elif isinstance(session, requests.session.Session):
+            # allows using e.g. proxy configuration defined explicitly
+            # besides standard environment variables like http_proxy, https_proxy, no_proxy and curl_ca_bundle
+            self.session = session
+        else:
+            raise TypeError(f"{type(session)=} must be a valid requests.session.Session object.")
+
         if auth is None:
             auth = requests.auth.HTTPBasicAuth(self.username, password if password else self.DEFAULT_PASSWORD)
         self.session.auth = auth

--- a/stardog/http/client.py
+++ b/stardog/http/client.py
@@ -17,7 +17,6 @@ class Client(object):
                  username=None,
                  password=None,
                  session=None,
-                 proxies=None,
                  auth=None):
         self.url = endpoint if endpoint else self.DEFAULT_ENDPOINT
 
@@ -30,11 +29,6 @@ class Client(object):
 
         if session is None:
             self.session = requests.Session()
-            if proxies is not None:
-                if isinstance(proxies, dict) and any([key in proxies.keys() for key in ('http', 'https')]):
-                    self.session.proxies.update(proxies)
-                else:
-                    raise TypeError(f"{proxies=} must be a dict of `'scheme': 'scheme://hostname'` item(s).")
         elif isinstance(session, requests.session.Session):
             # allows using e.g. proxy configuration defined explicitly
             # besides standard environment variables like http_proxy, https_proxy, no_proxy and curl_ca_bundle

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,8 +11,9 @@ def pytest_addoption(parser):
     parser.addoption("--username", action="store", default="admin")
     parser.addoption("--passwd", action="store", default="admin")
     parser.addoption("--endpoint", action="store", default="http://localhost:5820")
-    parser.addoption("--http_proxy", action="store", default=None)
-    parser.addoption("--https_proxy", action="store", default=None)
+    parser.addoption("--http_proxy", action="store", default="")
+    parser.addoption("--https_proxy", action="store", default="")
+    parser.addoption("--ssl_verify", action="store_true", default=True)
 
 @pytest.fixture
 def conn_string(pytestconfig):
@@ -25,14 +26,18 @@ def conn_string(pytestconfig):
 
 @pytest.fixture
 def proxies(pytestconfig):
-    proxies = {}
+    proxies_config = {}
     for protocol in ('http', 'https'):
         proxy_url = pytestconfig.getoption(f"{protocol}_proxy")
         if proxy_url is not None \
         and isinstance(proxy_url, str) \
         and proxy_url.startswith(protocol):
-            proxies.update({protocol: proxy_url})
-    return proxies
+            proxies_config.update({protocol: proxy_url})
+    return proxies_config
+
+@pytest.fixture
+def ssl_verify(pytestconfig):
+    return pytestconfig.getoption("ssl_verify")
 
 @pytest.fixture
 def bulkload_content():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,6 +11,8 @@ def pytest_addoption(parser):
     parser.addoption("--username", action="store", default="admin")
     parser.addoption("--passwd", action="store", default="admin")
     parser.addoption("--endpoint", action="store", default="http://localhost:5820")
+    parser.addoption("--http_proxy", action="store", default=None)
+    parser.addoption("--https_proxy", action="store", default=None)
 
 @pytest.fixture
 def conn_string(pytestconfig):
@@ -21,6 +23,16 @@ def conn_string(pytestconfig):
     }
     return conn
 
+@pytest.fixture
+def proxies(pytestconfig):
+    proxies = {}
+    for protocol in ('http', 'https'):
+        proxy_url = pytestconfig.getoption(f"{protocol}_proxy")
+        if proxy_url is not None \
+        and isinstance(proxy_url, str) \
+        and proxy_url.startswith(protocol):
+            proxies.update({protocol: proxy_url})
+    return proxies
 
 @pytest.fixture
 def bulkload_content():

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -8,12 +8,15 @@ import stardog.exceptions as exceptions
 
 
 @pytest.fixture()
-def conn(conn_string, proxies):
+def conn(conn_string, proxies, ssl_verify):
     if len(proxies):
         # create external session and configure connection
         session = requests.Session()
         # e.g. set proxies
         session.proxies.update(proxies)
+        # or optionally disable ssl_verification
+        # if MITM acting proxy or mysql connector doesn't support it
+        session.verify = ssl_verify
     else:
         session = None
     with connection.Connection('newtest', **conn_string, session=session) as conn:

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -8,8 +8,15 @@ import stardog.exceptions as exceptions
 
 
 @pytest.fixture()
-def conn(conn_string):
-    with connection.Connection('newtest', **conn_string) as conn:
+def conn(conn_string, proxies):
+    if len(proxies):
+        # create external session and configure connection
+        session = requests.Session()
+        # e.g. set proxies
+        session.proxies.update(proxies)
+    else:
+        session = None
+    with connection.Connection('newtest', **conn_string, session=session) as conn:
         yield conn
 
 


### PR DESCRIPTION
By default, `requests` package is configured with standard environment variables like `http_proxy` etc. This commit adds the possibility to set up a session explicitly without breaking anything.

If a session object is used, it needs to be created dynamically via eg. a `lambda`, as a terminated connection will close the session.