### PR TITLE
Fix/fix broken documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+  - epub
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ pystardog is on PyPI so all you need is: `pip install pystardog`
 Documentation is readable at [Read the
 Docs](http://pystardog.readthedocs.io) or can be built using Sphinx:
 
-    pip install -r requirements.txt
     cd docs
+    pip install -r requirements.txt
     make html
 
 ## Tests
@@ -35,7 +35,6 @@ Docker and docker-compose are also required.
 
 ```shell script
  docker-compose -f docker-compose.single-node.yml up --exit-code-from tests-single-node
-
  docker-compose -f docker-compose.cluster.yml up --exit-code-from tests
 
 ```
@@ -46,6 +45,7 @@ To run a format of all the files
 virtualenv -p $(which python3) venv
 . venv/bin/activate
 pip install -r test-requirements.txt
+black .
 ```
 
 ## Quick Example

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+Sphinx==4.4.0
+sphinx-rtd-theme==1.0.0
+contextlib2==21.6.0
+requests-toolbelt==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 requests==2.22.0
 requests-toolbelt==0.9.1
 contextlib2==0.5.5
-Sphinx==2.1.2
-sphinx-rtd-theme==0.4.3
 recommonmark==0.5.0

--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -1523,7 +1523,7 @@ class VirtualGraph(object):
         """Returns graph mappings as RDF
         Args:
           syntax (str): The desired RDF syntax of the mappings (STARDOG, R2RML, or SMS2).
-            Defaults to 'STARDOG'
+          Defaults to 'STARDOG'
 
         :return: Mappings in given content type
         :rtype: string
@@ -1538,7 +1538,7 @@ class VirtualGraph(object):
 
         Args:
           content_type (str): Content type for results.
-            Defaults to 'text/turtle'
+          Defaults to 'text/turtle'
 
         :return: Mappings in given content type
         :rtype: bytes


### PR DESCRIPTION
This fixes the errors in the documentation. 
Basically readthedocs uses by default python 3.7 for its builds. In the latest pystardog release, a [new feature](https://github.com/stardog-union/pystardog/pull/76) was included that uses syntax introduced only in python3.8+, which is the [equal sign in f strings](https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging).
This was silently breaking the builds for the docs. We had to force python3.8 for builds by using a .readthedocs.yaml config file.

See a working document here 
https://pystardog.readthedocs.io/en/fix-fix-broken-documentation/source/stardog.html
which hidden until we get this merged. we rolled back to 0.10.0 in RTD which is the working version.

Notes:
Can't use python 3.9 yet in the build. See https://stackoverflow.com/questions/65040971/why-is-pip3-install-netifaces-failing-on-debian-10-buster.
Issue opened here:
https://github.com/readthedocs/readthedocs.org/issues/9031
