### PR TITLE
Reverts a python 3.8 syntax introduced in pystardog 0.11.0

### DIFF
--- a/stardog/http/client.py
+++ b/stardog/http/client.py
@@ -31,13 +31,13 @@ class Client(object):
 
         if session is None:
             self.session = requests.Session()
-        elif isinstance(session, requests.session.Session):
+        elif isinstance(session, requests.Session):
             # allows using e.g. proxy configuration defined explicitly
             # besides standard environment variables like http_proxy, https_proxy, no_proxy and curl_ca_bundle
             self.session = session
         else:
             raise TypeError(
-                f"{type(session)=} must be a valid requests.session.Session object."
+                f"type(session) = {type(session)} must be a valid requests.Session object."
             )
 
         if auth is None:

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -404,3 +404,12 @@ def test_graphql(conn_string):
         assert len(gql.schemas()) == 0
 
     db.drop()
+
+
+def test_invalid_request_session(conn_string):
+    session = "im an invalid session"
+    with pytest.raises(
+        Exception,
+        match=f"type\(session\) = {type(session)} must be a valid requests\.Session object.",
+    ):
+        connection.Connection("somevaliddb", **conn_string, session=session)


### PR DESCRIPTION
Addresses #101 , #97 and #96 Also adds a test, as there were no tests for invalid sessions