### PR TITLE
Tests supported python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,17 @@
 ---
 version: 2.1
 
+installs_supported_python_versions: &installs_supported_python_versions
+  run:
+    name: Install supported python versions
+    no_output_timeout: 15m
+    command: |
+      set -x
+      sudo apt-get update -y
+      yes | sudo add-apt-repository ppa:deadsnakes/ppa || true
+      sudo apt-get install python3.{8,9,10,11} -yq
+      sudo apt-get install python3.{8,9}-distutils -yq
+
 run_basic_admin_suite: &run_basic_admin_suite
   run:
     name: Runs the basic admin suite
@@ -41,6 +52,16 @@ run_utils_tests: &run_utils_tests
       set -x
       pytest test/test_utils.py -s
 
+# See here for supported versions: https://devguide.python.org/versions/
+# We should support everything that's not EOL.
+run_test_supported_python_versions: &run_test_supported_python_versions
+  run:
+    name: Runs the test_utils suite against all supported python versions. 
+    no_output_timeout: 15m
+    command: |
+      set -x
+      tox
+
 setup_pytest: &setup_pytest
   run:
     name: Set up local env
@@ -64,7 +85,7 @@ pull_license: &pull_license
 jobs:
   static_analysis:
     docker:
-      - image: python:3.9
+      - image: python:latest
     steps:
       - checkout
       - run:
@@ -124,7 +145,16 @@ jobs:
           no_output_timeout: 15m
           command: |
             set -x
-            pytest test/test_single_node.py --endpoint http://localhost:5820 -s
+            pytest test/test_single_node.py -s
+            
+      - <<: *installs_supported_python_versions
+      - <<: *run_test_supported_python_versions
+      - run:
+          name: Runs the single_node_only_test against multiple python envs
+          no_output_timeout: 15m
+          command: |
+            set -x
+            tox -e single_node
 
   basic_test_cluster_mode:
     machine:
@@ -161,7 +191,15 @@ jobs:
           no_output_timeout: 15m
           command: |
             set -x
-            pytest test/test_cluster.py --endpoint http://localhost:5820 -s
+            pytest test/test_cluster.py -s
+
+      - <<: *installs_supported_python_versions
+      - run:
+          name: Runs the cluster node only tests against multiple python envs
+          no_output_timeout: 15m
+          command: |
+            set -x
+            tox -e cluster
 
 workflows:
   build_and_test:

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -1,8 +1,4 @@
-# Note that circleci docker executor does not allow to volume mounting, hence the volume block can't be used here.
-# https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
-# For this reason, we are creating specific dockerfiles, and building the images from them, copying the files in the images
-# instead of mounting them.
-
+---
 version: "3.3"
 services:
   zoo1:

--- a/docker-compose.single-node.yml
+++ b/docker-compose.single-node.yml
@@ -1,8 +1,4 @@
-# Note that circleci docker executor does not allow to volume mounting, hence the volume block can't be used here.
-# https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
-# For this reason, we are creating specific dockerfiles, and building the images from them, copying the files in the images
-# instead of mounting them.
-
+---
 version: "3.3"
 services:
   sd-single-node:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ black==22.3.0
 requests-mock==1.10.0
 pylint==2.15.9
 flake8==6.0.0
+tox==4.2.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist =
+    py3{11,10,9,8}
+
+[testenv]
+deps =
+    -r {toxinidir}/test-requirements.txt
+commands =
+      pytest test/test_admin_basic.py test/test_connection.py test/test_server_admin.py test/test_unit.py test/test_utils.py -s
+
+[testenv:cluster]
+deps =
+    -r {toxinidir}/test-requirements.txt
+commands =
+      pytest test/test_cluster.py -s
+
+[testenv:single_node]
+deps =
+    -r {toxinidir}/test-requirements.txt
+commands =
+      pytest test/test_single_node.py -s


### PR DESCRIPTION
Run tests against multiple python versions. We support starting 3.8, since 3.7 is about to get EOL.