### PR TITLE
Updates stardog test dockerfile

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 # Stardog version tag
+STARDOG_REPO=stardog/stardog
 STARDOG_TAG=latest
 STARDOG_USER=admin
 STARDOG_PASS=admin

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -14,7 +14,8 @@ services:
       context: dockerfiles/
       dockerfile: dockerfile-stardog
       args:
-        - TAG=${STARDOG_TAG}
+        - STARDOG_TAG=${STARDOG_TAG}
+        - STARDOG_REPO=${STARDOG_REPO}
         - NODE_TYPE=node
         - SSH_USER=${SSH_USER}
         - SSH_PASS=${SSH_PASS}
@@ -29,7 +30,8 @@ services:
       context: dockerfiles/
       dockerfile: dockerfile-stardog
       args:
-          - TAG=${STARDOG_TAG}
+          - STARDOG_TAG=${STARDOG_TAG}
+          - STARDOG_REPO=${STARDOG_REPO}
           - NODE_TYPE=node
           - SSH_USER=${SSH_USER}
           - SSH_PASS=${SSH_PASS}
@@ -44,7 +46,8 @@ services:
       context: dockerfiles/
       dockerfile: dockerfile-stardog
       args:
-        - TAG=${STARDOG_TAG}
+        - STARDOG_TAG=${STARDOG_TAG}
+        - STARDOG_REPO=${STARDOG_REPO}
         - NODE_TYPE=standby
         - SSH_USER=${SSH_USER}
         - SSH_PASS=${SSH_PASS}
@@ -59,7 +62,8 @@ services:
       context: dockerfiles/
       dockerfile: dockerfile-stardog
       args:
-        - TAG=${STARDOG_TAG}
+        - STARDOG_TAG=${STARDOG_TAG}
+        - STARDOG_REPO=${STARDOG_REPO}
         - NODE_TYPE=cache
         - SSH_USER=${SSH_USER}
         - SSH_PASS=${SSH_PASS}

--- a/docker-compose.single-node.yml
+++ b/docker-compose.single-node.yml
@@ -6,7 +6,8 @@ services:
       context: dockerfiles/
       dockerfile: dockerfile-stardog
       args:
-        - TAG=${STARDOG_TAG}
+        - STARDOG_TAG=${STARDOG_TAG}
+        - STARDOG_REPO=${STARDOG_REPO}
         - NODE_TYPE=single
     container_name: ${STARDOG_HOSTNAME_SINGLE_NODE}
     entrypoint: ["/bin/bash", "-c"]

--- a/dockerfiles/dockerfile-stardog
+++ b/dockerfiles/dockerfile-stardog
@@ -1,26 +1,26 @@
-FROM alpine as base
+ARG STARDOG_TAG
+ARG STARDOG_REPO
+FROM ${STARDOG_REPO}:${STARDOG_TAG}
+
+USER root
+RUN yes $SSH_PASS | passwd $SSH_USER
+RUN apt-get update -y && apt-get install openssh-server vim unzip wget -y
 
 ARG CONNECTOR_VERSION=8.0.21
 
 RUN wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${CONNECTOR_VERSION}.zip \
   && unzip mysql-connector-java-${CONNECTOR_VERSION}.zip \
-  && mv mysql-connector-java-${CONNECTOR_VERSION}/mysql-connector-java-${CONNECTOR_VERSION}.jar /tmp/mysql-connector-java.jar
-
-FROM stardog/stardog
+  && mv mysql-connector-java-${CONNECTOR_VERSION}/mysql-connector-java-${CONNECTOR_VERSION}.jar opt/stardog/server/dbms/mysql-connector-java.jar
 
 ARG NODE_TYPE
 ARG SSH_USER
 ARG SSH_PASS
 
-COPY --from=base /tmp/mysql-connector-java.jar opt/stardog/server/dbms
+# COPY /tmp/mysql-connector-java.jar opt/stardog/server/dbms
 COPY stardog-license-key.bin /var/opt/stardog
 COPY start.sh /var/start.sh
 COPY start-standby.sh /var/start-standby.sh
 COPY example.ttl /tmp/example-remote.ttl
-
-USER root
-RUN yes $SSH_PASS | passwd $SSH_USER
-RUN yum install openssh-server vim -y
 
 USER stardog
 # We require ssh to test that backups are successfully generated.

--- a/dockerfiles/dockerfile-stardog
+++ b/dockerfiles/dockerfile-stardog
@@ -16,7 +16,6 @@ ARG NODE_TYPE
 ARG SSH_USER
 ARG SSH_PASS
 
-# COPY /tmp/mysql-connector-java.jar opt/stardog/server/dbms
 COPY stardog-license-key.bin /var/opt/stardog
 COPY start.sh /var/start.sh
 COPY start-standby.sh /var/start-standby.sh

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -882,7 +882,7 @@ class GraphQL:
           with named variables
 
           >>> gql.query(
-                'query getPerson($id: Integer) { Person(id: $id) {name} }',
+                'query getPerson($id: Int) { Person(id: $id) {name} }',
                 variables={'id': 1000})
 
         """

--- a/test/data/icv_report.ttl
+++ b/test/data/icv_report.ttl
@@ -1,4 +1,5 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix so: <https://schema.org/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix : <http://api.stardog.com/> .
@@ -11,4 +12,5 @@
     a sh:ValidationReport ;
     sh:conforms true
 ] .
+
 

--- a/test/test_admin_basic.py
+++ b/test/test_admin_basic.py
@@ -12,8 +12,9 @@ from stardog import admin, connection, content, content_types, exceptions
 ###############################################################
 from stardog.exceptions import StardogException
 
-default_users = ["admin", "anonymous"]
+default_users = ["admin"]
 default_roles = ["reader"]
+default_namespace_count = 7
 
 
 class Resource(Enum):
@@ -294,11 +295,10 @@ class TestDatabase(TestStardog):
 # both gets cleaned up as part of the fixture.
 class TestNamespaces(TestStardog):
     def test_add_and_delete_namespaces(self, db):
-        # number of namespaces is always 6 by default for any new database
-        assert len(db.namespaces()) == 6
+        assert len(db.namespaces()) == default_namespace_count
 
         db.add_namespace("testns", "my:test:IRI")
-        assert len(db.namespaces()) == 7
+        assert len(db.namespaces()) == default_namespace_count + 1
 
         # tests a failure while adding an existing namespace
         with pytest.raises(
@@ -307,7 +307,7 @@ class TestNamespaces(TestStardog):
             db.add_namespace("stardog", "someiri")
 
         db.remove_namespace("testns")
-        assert len(db.namespaces()) == 6
+        assert len(db.namespaces()) == default_namespace_count
 
         # tests a failure while removing an existing namespace
         with pytest.raises(
@@ -319,13 +319,13 @@ class TestNamespaces(TestStardog):
         db.add_namespace("testnspace", "my:test:IRI")
         db.add_namespace("testns", "my:test:IRI")
 
-        assert len(db.namespaces()) == 8
+        assert len(db.namespaces()) == default_namespace_count + 2
 
         # tests removal of the correct namespace, even if a similar namespace exists
         db.remove_namespace("testns")
         db.remove_namespace("testnspace")
 
-        assert len(db.namespaces()) == 6
+        assert len(db.namespaces()) == default_namespace_count
 
     def test_import_namespaces(self, db):
         # we want to tests more than 1 file format
@@ -335,9 +335,9 @@ class TestNamespaces(TestStardog):
         db_default_namespaces = db.namespaces()
         ns_default_count = len(db_default_namespaces)
 
-        # number of namespaces is always 6 by default for any new database
+        # number of namespaces is a fixed number set to default_namespace_count by default for any new database
         # https://docs.stardog.com/operating-stardog/database-administration/managing-databases#namespaces
-        assert ns_default_count == 6
+        assert ns_default_count == default_namespace_count
 
         # imports 4 namespaces
         db.import_namespaces(namespaces_ttl)

--- a/test/utils/wait.sh
+++ b/test/utils/wait.sh
@@ -73,7 +73,6 @@ function wait_for_start_single_node {
       fi
       COUNT=$(expr 1 + ${COUNT} )
       sleep 5
-
       curl -s http://${HOST}:${PORT}/admin/healthcheck -u admin:admin
       if [ $? -eq 0 ]; then
         echo "Stardog server single node up and running"


### PR DESCRIPTION
* Stardog 9 changed base image from centos to ubuntu, so yum is no longer available:
https://docs.stardog.com/release-notes/stardog-platform#900-release-2023-04-05
> Docker image changed from CentOS 7 to Ubuntu 22.04 (#PLAT-1886)

* Updates some pystardog integration tests, as Stardog 9.0.0 introduced a new changes.
* Moves some connection tests to use pytest fixtures.