### PR TITLE
Feature/cloud 1284 Apple silicon test fixes

### DIFF
--- a/dockerfiles/dockerfile-mysql-music
+++ b/dockerfiles/dockerfile-mysql-music
@@ -1,4 +1,4 @@
-FROM mysql:8.0.3
+FROM mysql:8.0.33
 
 # RUN apt-get update && apt-get install -y vim nano
 

--- a/dockerfiles/dockerfile-mysql-videos
+++ b/dockerfiles/dockerfile-mysql-videos
@@ -1,4 +1,4 @@
-FROM mysql:8.0.3
+FROM mysql:8.0.33
 
 # RUN apt-get update && apt-get install -y vim nano
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -98,7 +98,7 @@ def music_options():
         "jdbc.username": "user",
         "jdbc.password": "pass",
         "mappings.syntax": "STARDOG",
-        "jdbc.url": "jdbc:mysql://pystardog_mysql_music/music?useSSL=false",
+        "jdbc.url": "jdbc:mysql://pystardog_mysql_music/music?allowPublicKeyRetrieval=true&useSSL=false",
     }
     return options
 


### PR DESCRIPTION
Update mysql version to 8.0.33

* Bump both dockerfiles to 8.0.33 since this version supports Apple
Silicon

* Change JDBC url to support new version

The new version required me to add "allowPublicKeyRetrieval=true"
to jdbc urls in order for it to work.

* Remove is_local and usages of it

The current method for checking if the tests are running locally
did not work on my Apple silicon machine. Per Simon's advice
I removed the check since the tests should always be run in
docker anyway.