### PR TITLE
[CLOUD-1366]: add support for impersonating users

### DIFF
--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -26,6 +26,7 @@ class Admin:
         username: object = None,
         password: object = None,
         auth: object = None,
+        run_as: str = None,
     ) -> None:
         """Initializes an admin connection to a Stardog server.
 
@@ -36,8 +37,9 @@ class Admin:
             Defaults to `admin`
           password (str, optional): Password to use in the connection.
             Defaults to `admin`
-        auth (requests.auth.AuthBase, optional): requests Authentication object.
+          auth (requests.auth.AuthBase, optional): requests Authentication object.
             Defaults to `None`
+          run_as (str, optional): the User to impersonate
 
         auth and username/password should not be used together.  If the are the value
         of `auth` will take precedent.
@@ -45,7 +47,9 @@ class Admin:
           >>> admin = Admin(endpoint='http://localhost:9999',
                             username='admin', password='admin')
         """
-        self.client = client.Client(endpoint, None, username, password, auth=auth)
+        self.client = client.Client(
+            endpoint, None, username, password, auth=auth, run_as=run_as
+        )
         # ensure the server is alive and at the specified location
         self.alive()
 

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -25,6 +25,7 @@ class Connection:
         password=None,
         auth=None,
         session=None,
+        run_as=None,
     ):
         """Initializes a connection to a Stardog database.
 
@@ -38,13 +39,20 @@ class Connection:
             Defaults to `None`
           session (requests.session.Session, optional): requests Session object.
             Defaults to `None`
+          run_as (str, optional): the user to impersonate
 
         Examples:
           >>> conn = Connection('db', endpoint='http://localhost:9999',
                                 username='admin', password='admin')
         """
         self.client = client.Client(
-            endpoint, database, username, password, auth=auth, session=session
+            endpoint,
+            database,
+            username,
+            password,
+            auth=auth,
+            session=session,
+            run_as=run_as,
         )
         self.transaction = None
 

--- a/stardog/http/client.py
+++ b/stardog/http/client.py
@@ -18,6 +18,7 @@ class Client:
         password=None,
         session=None,
         auth=None,
+        run_as=None,
     ):
         self.url = endpoint if endpoint else self.DEFAULT_ENDPOINT
 
@@ -44,6 +45,9 @@ class Client:
                 self.username, password if password else self.DEFAULT_PASSWORD
             )
         self.session.auth = auth
+
+        if run_as:
+            self.session.headers.update({"SD-Run-As": run_as})
 
     def post(self, path, **kwargs):
         return self.__wrap(self.session.post(self.url + path, **kwargs))

--- a/test/test_admin_basic.py
+++ b/test/test_admin_basic.py
@@ -104,8 +104,10 @@ class TestUserImpersonation(TestStardog):
             ]
         assert len(databases_impersonated_user_can_see) == 0
 
-        # catalog db and database created by the `db` fixture
-        assert len(databases_admin_can_see) == 2
+        # for cluster tests in Circle, catalog is disabled so the exact number of dbs
+        # varies (2 for single node, 1 for cluster since catalog isn't created)
+        assert len(databases_admin_can_see) > 0
+        assert db.name in databases_admin_can_see
 
 
 class TestUsers(TestStardog):

--- a/test/test_admin_basic.py
+++ b/test/test_admin_basic.py
@@ -88,6 +88,26 @@ class TestStardog:
         }
 
 
+class TestUserImpersonation(TestStardog):
+    def test_impersonating_user_databases_visibility(self, conn_string, user, db):
+
+        with admin.Admin(
+            endpoint=conn_string["endpoint"],
+        ) as admin_user:
+            databases_admin_can_see = [db.name for db in admin_user.databases()]
+        with admin.Admin(
+            endpoint=conn_string["endpoint"],
+            run_as=user.name,
+        ) as admin_impersonating_user:
+            databases_impersonated_user_can_see = [
+                db.name for db in admin_impersonating_user.databases()
+            ]
+        assert len(databases_impersonated_user_can_see) == 0
+
+        # catalog db and database created by the `db` fixture
+        assert len(databases_admin_can_see) == 2
+
+
 class TestUsers(TestStardog):
     def test_user_creation(self, admin, user):
         assert len(admin.users()) == len(default_users) + 1

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -114,7 +114,7 @@ def test_user_impersonation(conn_string, db, user):
         q = admin_regular_conn.select('select * {?s :name "Luke Skywalker"}')
         assert len(q["results"]["bindings"]) == 1
 
-    # attempting to query database as user is impersonating should return an unauthorized error
+    # attempting to query database as the user the admin is impersonating should return an unauthorized error
     with connection.Connection(
         endpoint=conn_string["endpoint"], database=db.name, run_as=user.name
     ) as admin_impersonating_user:


### PR DESCRIPTION
Adds support for impersonating users via a regular connection and admin connection.

Example admin connection impersonating user:

```python
admin_impersonating_regular_user = Admin(
                            endpoint='http://localhost:5820',
                            username='admin', 
                            password='admin'
                            run_as="regular_user"
                            )

```

Stardog expects the incoming request to have an HTTP header named `SD-Run-As` with a value of the username you wish to impersonate:

Example:
`SD-Run-As: bob`

