### PR TITLE
feat: add support for query datasets

### DIFF
--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -423,8 +423,8 @@ class Connection:
             values
           content_type (str): Content type for results.
               Defaults to 'application/sparql-results+json'
-          default_graph_uri (list[str], optional): URI(s) to be used as the default graph (equivalent to FROM)
-          named_graph_uri (list[str], optional): URI(s) to be used as named graphs (equivalent to FROM NAMED)
+          default_graph_uri (str, list[str], optional): URI(s) to be used as the default graph (equivalent to FROM)
+          named_graph_uri (str, list[str], optional): URI(s) to be used as named graphs (equivalent to FROM NAMED)
 
         Returns:
           dict: if content_type='application/sparql-results+json'.

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -2,6 +2,7 @@
 """
 
 import contextlib
+from typing import Dict, Optional
 
 from . import content_types as content_types
 from . import exceptions as exceptions
@@ -318,6 +319,12 @@ class Connection:
             "timeout": kwargs.get("timeout"),
             "reasoning": kwargs.get("reasoning"),
             "prettify": kwargs.get("prettify"),
+            "default-graph-uri": kwargs.get("default_graph_uri"),
+            "named-graph-uri": kwargs.get("named_graph_uri"),
+            "using-graph-uri": kwargs.get("using_graph_uri"),
+            "using-named-graph-uri": kwargs.get("using_named_graph_uri"),
+            "remove-graph-uri": kwargs.get("remove_graph_uri"),
+            "insert-graph-uri": kwargs.get("insert_graph_uri"),
         }
 
         # query bindings
@@ -350,6 +357,9 @@ class Connection:
             values
           content_type (str, optional): Content type for results.
             Defaults to 'application/sparql-results+json'
+          default_graph_uri (str, list[str], optional): URI(s) to be used as the default graph (equivalent to FROM)
+          named_graph_uri (str, list[str], optional): URI(s) to be used as named graphs (equivalent to FROM NAMED)
+
 
         Returns:
           dict: If content_type='application/sparql-results+json'
@@ -382,6 +392,8 @@ class Connection:
             values
           content_type (str): Content type for results.
             Defaults to 'text/turtle'
+          default_graph_uri (str, list[str], optional): URI(s) to be used as the default graph (equivalent to FROM)
+          named_graph_uri (str, list[str], optional): URI(s) to be used as named graphs (equivalent to FROM NAMED)
 
         Returns:
           str: Results in format given by content_type
@@ -412,6 +424,8 @@ class Connection:
             values
           content_type (str): Content type for results.
               Defaults to 'application/sparql-results+json'
+          default_graph_uri (list[str], optional): URI(s) to be used as the default graph (equivalent to FROM)
+          named_graph_uri (list[str], optional): URI(s) to be used as named graphs (equivalent to FROM NAMED)
 
         Returns:
           dict: if content_type='application/sparql-results+json'.
@@ -438,6 +452,8 @@ class Connection:
           reasoning (bool, optional): Enable reasoning for the query
           bindings (dict, optional): Map between query variables and their
             values
+          default_graph_uri (str, list[str], optional): URI(s) to be used as the default graph (equivalent to FROM)
+          named_graph_uri (str, list[str], optional): URI(s) to be used as named graphs (equivalent to FROM NAMED)
 
         Returns:
           bool: Result of ask query
@@ -461,6 +477,10 @@ class Connection:
           reasoning (bool, optional): Enable reasoning for the query
           bindings (dict, optional): Map between query variables and their
             values
+          using_graph_uri (str, list[str], optional): URI(s) to be used as the default graph (equivalent to USING)
+          using_named_graph_uri (str, list[str], optional): URI(s) to be used as named graphs (equivalent to USING NAMED)
+          remove_graph_uri (str, optional): URI of the graph to be removed from
+          insert_graph_uri (str, optional): URI of the graph to be inserted into
 
         Examples:
           >>> conn.update('delete where {?s ?p ?o}')

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -2,7 +2,6 @@
 """
 
 import contextlib
-from typing import Dict, Optional
 
 from . import content_types as content_types
 from . import exceptions as exceptions


### PR DESCRIPTION
Adds support for [query datasets](https://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/#dataset):

That is for `SELECT`/`CONSTRUCT`/`PATHS`/`ASK` SPARQL query types:
- `default-graph-uri` - URI(s) to be used as the default graph (equivalent to `FROM`)
- `named-graph-uri` - URI(s) to be used as named graphs (equivalent to `FROM NAMED`)

can now be supplied as a parameter to their respective methods.

```python
   default_graph_dataset = ["http://graph1", "http://graph2"]

    response = conn.select(
        query="select * { ?s ?p ?o }",
        default_graph_uri=default_graph_dataset,
    )
```

For SPARQL Update queries, the following parameters are now available on the `update` method:

- `using-graph-uri` - URI(s) to be used as the default graph (equivalent to `USING`)
- `using-named-graph-uri`- URI(s) to be used as named graphs (equivalent to `USING NAMED`)
- `remove-graph-uri` - URI of the graph to be inserted into
- `insert-graph-uri` - URI of the graph to be removed from


For example, the following code will add the triples defined in the `INSERT DATA` clause to `the_graph`:

```python
    the_graph = "http://my-graph"
    insert_data = """
    INSERT DATA {
        <ex:a> <ex:b> <ex:c> .
        <ex:d> <ex:e> <ex:f> .
    }
    """
    
    conn.begin()
    conn.update(query=insert_data, insert_graph_uri=the_graph)
    conn.commit()

    response = conn.select(
        query="select * { ?s ?p ?o }",
        default_graph_uri=[the_graph],
    )
    assert len(response["results"]["bindings"]) == 2
```

I added minimal tests for all the parameters above - more tests could probably be done for `ASK`/  `CONSTRUCT` /  `PATHS` but I think these can come later. 

All of the new parameters mentioned above are all documented in the Stardog HTTP API docs: https://stardog-union.github.io/http-docs/#tag/SPARQL/operation/updatePost

Closes #32 

