### PR TITLE
Fixes docs momentarily

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ Sphinx==4.4.0
 sphinx-rtd-theme==1.0.0
 contextlib2==21.6.0
 requests-toolbelt==0.9.1
+recommonmark==0.5.0
+requests==2.28.1


### PR DESCRIPTION
This is only temporarily to fix the docs.
We should focus on upgrading the requests library to the latest version asap, due to:
https://github.com/stardog-union/pystardog/security/dependabot/1