### PR TITLE
[PLAT-4257] - return results from committing a transaction

### DIFF
--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -2,12 +2,27 @@
 """
 
 import contextlib
+from typing import Dict, TypedDict
 
 from . import content_types as content_types
 from . import exceptions as exceptions
 from .http import client
 from .utils import strtobool
 import urllib
+
+
+class CommitResult(TypedDict):
+    """The result of committing a transaction.
+
+    Represents the outcome of a transaction commit operation, including the counts
+    of added and removed triples.
+    """
+
+    added: int
+    """ The amount of triples added in the transaction """
+
+    removed: int
+    """ The amount of triples removed in the transaction """
 
 
 class Connection:
@@ -122,7 +137,7 @@ class Connection:
         self.client.post("/transaction/rollback/{}".format(self.transaction))
         self.transaction = None
 
-    def commit(self):
+    def commit(self) -> CommitResult:
         """Commits the current transaction.
 
         Raises:
@@ -130,8 +145,10 @@ class Connection:
             If currently not in a transaction
         """
         self._assert_in_transaction()
-        self.client.post("/transaction/commit/{}".format(self.transaction))
+        resp = self.client.post("/transaction/commit/{}".format(self.transaction))
         self.transaction = None
+
+        return resp.json()
 
     def add(self, content, graph_uri=None, server_side=False):
         """Adds data to the database.

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -2,7 +2,7 @@
 """
 
 import contextlib
-from typing import Dict, TypedDict
+from typing import TypedDict
 
 from . import content_types as content_types
 from . import exceptions as exceptions

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -7,6 +7,28 @@ def starwars_contents() -> list:
     return content.File("test/data/starwars.ttl")
 
 
+@pytest.mark.dbname("pystardog-test-database")
+@pytest.mark.conn_dbname("pystardog-test-database")
+def test_commit(db, conn: connection.Connection):
+    data = content.Raw("<urn:subj> <urn:pred> <urn:obj> .", content_types.TURTLE)
+
+    conn.begin()
+    conn.clear()
+    conn.add(data)
+
+    result = conn.commit()
+
+    assert result["added"] == 1
+    assert result["removed"] == 0
+
+    conn.begin()
+    conn.remove(data)
+
+    result = conn.commit()
+    assert result["added"] == 0
+    assert result["removed"] == 1
+
+
 @pytest.mark.skip(
     reason="Currently failing, check out another branch and see if it fails there."
 )


### PR DESCRIPTION
Adds a response to the `commit` method. There is some helpful information in that response like the number of triples added/removed in that transaction.

Example usage:

```python
    result = conn.commit()

    print(f"Triples added: {result["added"]}")
    print(f"Triples removed: {result["removed"]}")
``` 

