### PR TITLE
chore: bump dependencies for doc generation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-Sphinx==4.4.0
-sphinx-rtd-theme==1.0.0
+Sphinx==6.2.1
+sphinx-rtd-theme==1.2.2
 contextlib2==21.6.0
 requests-toolbelt==0.9.1
 recommonmark==0.5.0


### PR DESCRIPTION
- Bumps [`sphinx_rtd_theme`](https://github.com/readthedocs/sphinx_rtd_theme) to its latest release - v1.2.2
- Bumps `sphinx` to its latest v6 release - v6.2.3
   - v7 is out but `sphinx_rdt_theme` does not yet support it. There is an open issue and it has been added to their planned roadmap fwiw: [sphinx_rtd_theme](https://github.com/readthedocs/sphinx_rtd_theme) 