### PR TITLE
fix: stardog.results module failed to deploy on rtd due to missing deps

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,4 +23,5 @@ formats:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
+   - requirements: requirements.txt
    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -217,3 +217,4 @@ To format all the Python code:
   # run black formatter
   black .
   ```
+


### PR DESCRIPTION
Noticed the new `stardog.results` module I added does not have docs on RTD. The section is just empty.

![Screenshot 2025-04-14 at 12 37 07 PM](https://github.com/user-attachments/assets/8c321435-d366-473d-9f7c-b16b3ae73c45)


 Looks to be due to Sphinx not having the `rdflib` dependency when building the docs. See this snippet from the[ build logs](https://app.readthedocs.org/projects/pystardog/builds/27850936/):

```
WARNING: autodoc: failed to import module 'connection' from module 'stardog'; the following exception was raised:
--
15 | No module named 'rdflib'
16 | WARNING: autodoc: failed to import module 'results' from module 'stardog'; the following exception was raised:
17 | No module named 'rdflib'
18 | looking for now-outdated files... none found
```

When I build the docs locally with all deps, I see the section populated:

![image](https://github.com/user-attachments/assets/2dab1844-40a4-49e0-9474-21bc8fa14f41)


> [!NOTE]
> You can validate the changes by seeing the PR build: https://pystardog--181.org.readthedocs.build/en/181/source/stardog.html#module-stardog.results