### PR TITLE
CLOUD-2558: stop advertising and testing 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ installs_supported_python_versions: &installs_supported_python_versions
       sudo apt-get update -y
       yes | sudo add-apt-repository ppa:deadsnakes/ppa || true
       sudo apt-get install python3.{9,10,11,12,13} -yq
-      sudo apt-get install python3.{9}-distutils -yq
+      sudo apt-get install python3.9-distutils -yq
 
 run_basic_admin_suite: &run_basic_admin_suite
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ installs_supported_python_versions: &installs_supported_python_versions
       sudo apt-get update -y
       yes | sudo add-apt-repository ppa:deadsnakes/ppa || true
       sudo apt-get install python3.{9,10,11,12,13} -yq
+      sudo apt-get install python3.{9}-distutils -yq
 
 run_basic_admin_suite: &run_basic_admin_suite
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,7 @@ installs_supported_python_versions: &installs_supported_python_versions
       set -x
       sudo apt-get update -y
       yes | sudo add-apt-repository ppa:deadsnakes/ppa || true
-      sudo apt-get install python3.{8,9,10,11} -yq
-      sudo apt-get install python3.{8,9}-distutils -yq
+      sudo apt-get install python3.{9,10,11,12,13} -yq
 
 run_basic_admin_suite: &run_basic_admin_suite
   run:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ a Python wrapper for communicating with the Stardog HTTP server.
 
 **Docs**: [http://pystardog.readthedocs.io](http://pystardog.readthedocs.io)
 
-**Requirements**: Python 3.8+
+**Requirements**: Python 3.9+
 
 ## What is it?
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{11,10,9,8}
+    py3{13,12,11,10,9}
 
 [testenv]
 deps =


### PR DESCRIPTION
also test more recent versions of python (3.12/13).

> [!NOTE]
> Python 3.14 will be released later this year and 3.9 will be EOL. See https://devguide.python.org/versions/#status-of-python-versions for more info.