### PR TITLE
fix: ensure docs have the cloud deps in order to build cloud api reference

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,4 +26,5 @@ python:
    - method: pip
      path: .
      extra_requirements:
+       - cloud
        - docs


### PR DESCRIPTION
RTD failed to generate the API docs for the cloud module because it needed the cloud deps:

<img width="1004" height="120" alt="image" src="https://github.com/user-attachments/assets/e06f2ea3-2010-4c74-b6aa-8c8391bb1dbc" />

<img width="1002" height="355" alt="image" src="https://github.com/user-attachments/assets/fee4f3d0-8561-4555-a3e3-f631043a9237" />
