### PR TITLE
PLAT-8865: implement query_id in connection.py

### DIFF
--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -336,7 +336,10 @@ class Connection:
             "insert-graph-uri": kwargs.get("insert_graph_uri"),
             "schema": kwargs.get("schema"),
         }
-        request_params = {"id": kwargs.get("query_id")}
+        request_params = {}
+        query_id = kwargs.get("query_id")
+        if query_id is not None:
+            request_params["id"] = query_id
 
         # query bindings
         bindings = kwargs.get("bindings", {})
@@ -387,7 +390,7 @@ class Connection:
         :param content_type: Content type for results.
         :param default_graph_uri: URI(s) to be used as the default graph (equivalent to ``FROM``)
         :param named_graph_uri: URI(s) to be used as named graphs (equivalent to ``FROM NAMED``)
-        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
+        :param query_id: User-defined identifier for the query. Useful for tracking queries in the Stardog query log or cancelling a running query via the admin API.
 
         :return: If ``content_type='application/sparql-results+json'``, results will be returned as a Dict, else results will be returned as bytes.
 
@@ -452,7 +455,7 @@ class Connection:
         :param content_type: Content type for results.
         :param default_graph_uri: URI(s) to be used as the default graph (equivalent to ``FROM``)
         :param named_graph_uri: URI(s) to be used as named graphs (equivalent to ``FROM NAMED``)
-        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
+        :param query_id: User-defined identifier for the query. Useful for tracking queries in the Stardog query log or cancelling a running query via the admin API.
 
         :return: the query results
 
@@ -517,7 +520,7 @@ class Connection:
         :param content_type: Content type for results.
         :param default_graph_uri: URI(s) to be used as the default graph (equivalent to ``FROM``)
         :param named_graph_uri: URI(s) to be used as named graphs (equivalent to ``FROM NAMED``)
-        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
+        :param query_id: User-defined identifier for the query. Useful for tracking queries in the Stardog query log or cancelling a running query via the admin API.
 
         :return: If ``content_type='application/sparql-results+json'``, results will be returned as a Dict
             , else results will be returned as bytes.
@@ -576,7 +579,7 @@ class Connection:
         :param bindings: Map between query variables and their values
         :param default_graph_uri: URI(s) to be used as the default graph (equivalent to ``FROM``)
         :param named_graph_uri: URI(s) to be used as named graphs (equivalent to ``FROM NAMED``)
-        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
+        :param query_id: User-defined identifier for the query. Useful for tracking queries in the Stardog query log or cancelling a running query via the admin API.
 
         :return: whether the query pattern has a solution or not
 
@@ -639,7 +642,7 @@ class Connection:
         :param using_named_graph_uri: URI(s) to be used as named graphs (equivalent to ``USING NAMED``)
         :param remove_graph_uri: URI of the graph to be removed from
         :param insert_graph_uri: URI of the graph to be inserted into
-        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
+        :param query_id: User-defined identifier for the query. Useful for tracking queries in the Stardog query log or cancelling a running query via the admin API.
 
         Examples:
           >>> conn.update('delete where {?s ?p ?o}')

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -336,6 +336,7 @@ class Connection:
             "insert-graph-uri": kwargs.get("insert_graph_uri"),
             "schema": kwargs.get("schema"),
         }
+        request_params = {"id": kwargs.get("query_id")}
 
         # query bindings
         bindings = kwargs.get("bindings", {})
@@ -351,6 +352,7 @@ class Connection:
 
         r = self.client.post(
             url,
+            params=request_params,
             data=params,
             headers={"Accept": content_type},
         )
@@ -369,6 +371,7 @@ class Connection:
         content_type: str = content_types.SPARQL_JSON,
         default_graph_uri: Optional[List[str]] = None,
         named_graph_uri: Optional[List[str]] = None,
+        query_id: Optional[str] = None,
         **kwargs,
     ) -> Union[bytes, Dict]:
         """Executes a SPARQL select query.
@@ -384,6 +387,7 @@ class Connection:
         :param content_type: Content type for results.
         :param default_graph_uri: URI(s) to be used as the default graph (equivalent to ``FROM``)
         :param named_graph_uri: URI(s) to be used as named graphs (equivalent to ``FROM NAMED``)
+        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
 
         :return: If ``content_type='application/sparql-results+json'``, results will be returned as a Dict, else results will be returned as bytes.
 
@@ -416,6 +420,7 @@ class Connection:
             bindings=bindings,
             default_graph_uri=default_graph_uri,
             named_graph_uri=named_graph_uri,
+            query_id=query_id,
             **kwargs,
         )
 
@@ -431,6 +436,7 @@ class Connection:
         content_type=content_types.TURTLE,
         default_graph_uri: Optional[List[str]] = None,
         named_graph_uri: Optional[List[str]] = None,
+        query_id: Optional[str] = None,
         **kwargs,
     ) -> bytes:
         """Executes a SPARQL graph (``CONSTRUCT``) query.
@@ -446,6 +452,7 @@ class Connection:
         :param content_type: Content type for results.
         :param default_graph_uri: URI(s) to be used as the default graph (equivalent to ``FROM``)
         :param named_graph_uri: URI(s) to be used as named graphs (equivalent to ``FROM NAMED``)
+        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
 
         :return: the query results
 
@@ -478,6 +485,7 @@ class Connection:
             bindings=bindings,
             default_graph_uri=default_graph_uri,
             named_graph_uri=named_graph_uri,
+            query_id=query_id,
             **kwargs,
         )
 
@@ -493,6 +501,7 @@ class Connection:
         content_type=content_types.SPARQL_JSON,
         default_graph_uri: Optional[List[str]] = None,
         named_graph_uri: Optional[List[str]] = None,
+        query_id: Optional[str] = None,
         **kwargs,
     ) -> Union[Dict, bytes]:
         """Executes a SPARQL paths query.
@@ -508,6 +517,7 @@ class Connection:
         :param content_type: Content type for results.
         :param default_graph_uri: URI(s) to be used as the default graph (equivalent to ``FROM``)
         :param named_graph_uri: URI(s) to be used as named graphs (equivalent to ``FROM NAMED``)
+        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
 
         :return: If ``content_type='application/sparql-results+json'``, results will be returned as a Dict
             , else results will be returned as bytes.
@@ -536,6 +546,7 @@ class Connection:
             bindings=bindings,
             default_graph_uri=default_graph_uri,
             named_graph_uri=named_graph_uri,
+            query_id=query_id,
             **kwargs,
         )
 
@@ -550,6 +561,7 @@ class Connection:
         bindings: Optional[Dict[str, str]] = None,
         default_graph_uri: Optional[List[str]] = None,
         named_graph_uri: Optional[List[str]] = None,
+        query_id: Optional[str] = None,
         **kwargs,
     ) -> bool:
         """Executes a SPARQL ``ASK`` query.
@@ -564,6 +576,7 @@ class Connection:
         :param bindings: Map between query variables and their values
         :param default_graph_uri: URI(s) to be used as the default graph (equivalent to ``FROM``)
         :param named_graph_uri: URI(s) to be used as named graphs (equivalent to ``FROM NAMED``)
+        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
 
         :return: whether the query pattern has a solution or not
 
@@ -591,6 +604,7 @@ class Connection:
             bindings=bindings,
             default_graph_uri=default_graph_uri,
             named_graph_uri=named_graph_uri,
+            query_id=query_id,
             **kwargs,
         )
         return strtobool(r.decode())
@@ -608,6 +622,7 @@ class Connection:
         using_named_graph_uri: Optional[List[str]] = None,
         remove_graph_uri: Optional[str] = None,
         insert_graph_uri: Optional[str] = None,
+        query_id: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Executes a SPARQL update query.
@@ -624,6 +639,7 @@ class Connection:
         :param using_named_graph_uri: URI(s) to be used as named graphs (equivalent to ``USING NAMED``)
         :param remove_graph_uri: URI of the graph to be removed from
         :param insert_graph_uri: URI of the graph to be inserted into
+        :param query_id: Optional query identifier to send as the request URL ``id`` parameter
 
         Examples:
           >>> conn.update('delete where {?s ?p ?o}')
@@ -643,6 +659,7 @@ class Connection:
             using_named_graph_uri=using_named_graph_uri,
             remove_graph_uri=remove_graph_uri,
             insert_graph_uri=insert_graph_uri,
+            query_id=query_id,
             **kwargs,
         )
 

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,6 +1,8 @@
 import pytest
+import threading
+import uuid
 
-from stardog import connection, content, content_types, exceptions
+from stardog import admin as admin_module, connection, content, content_types, exceptions
 
 
 def starwars_contents() -> list:
@@ -820,3 +822,94 @@ def test_icv_reasoning_enabled(db, conn):
     icv = conn.icv()
     res = icv.report(**{"reasoning": True})
     assert res == open("test/data/icv_report.ttl").read()
+
+
+@pytest.mark.dbname("pystardog-test-database")
+@pytest.mark.conn_dbname("pystardog-test-database")
+def test_select_with_query_id(admin, db, conn: connection.Connection):
+    """Verify that passing a query_id does not break query execution."""
+    query_id = f"pystardog-test-{uuid.uuid4()}"
+
+    result = conn.select(
+        "select * where { ?s ?p ?o }",
+        limit=1,
+        query_id=query_id,
+    )
+
+    assert "results" in result
+    assert "bindings" in result["results"]
+
+
+@pytest.mark.dbname("pystardog-test-database")
+@pytest.mark.conn_dbname("pystardog-test-database")
+def test_update_with_query_id(admin, db, conn: connection.Connection):
+    """Verify that passing a query_id does not break update execution."""
+    query_id = f"pystardog-test-{uuid.uuid4()}"
+
+    conn.begin()
+    conn.update(
+        "INSERT DATA { <urn:qid-test-s> <urn:qid-test-p> <urn:qid-test-o> }",
+        query_id=query_id,
+    )
+    conn.commit()
+
+
+@pytest.mark.dbname("pystardog-test-database")
+@pytest.mark.conn_dbname("pystardog-test-database")
+def test_query_id_visible_in_running_queries(admin, db, conn: connection.Connection, conn_string):
+    """Verify that a custom query_id is visible via the admin running queries API."""
+    query_id = f"pystardog-test-{uuid.uuid4()}"
+
+    # Add enough data so a cross-product query runs long enough to observe
+    data = content.Raw(
+        "\n".join(
+            f"<urn:s{i}> <urn:p{j}> <urn:o{k}> ."
+            for i in range(30)
+            for j in range(30)
+            for k in range(1)
+        ),
+        content_types.TURTLE,
+    )
+    conn.begin()
+    conn.add(data)
+    conn.commit()
+
+    # Run a slow cross-product query in a background thread
+    query_error = []
+
+    def slow_query():
+        try:
+            # Use a separate connection so we don't interfere with the main one
+            with connection.Connection("pystardog-test-database", **conn_string) as bg_conn:
+                bg_conn.select(
+                    "SELECT * WHERE { ?a ?b ?c . ?d ?e ?f . ?g ?h ?i . ?j ?k ?l }",
+                    query_id=query_id,
+                )
+        except Exception as e:
+            query_error.append(e)
+
+    t = threading.Thread(target=slow_query)
+    t.start()
+
+    try:
+        # Poll for the query to appear in the running queries list
+        import time
+
+        found = False
+        for _ in range(20):
+            time.sleep(0.5)
+            try:
+                query_info = admin.query(query_id)
+                found = True
+                break
+            except Exception:
+                continue
+
+        assert found, f"Query {query_id} was never visible in admin running queries"
+    finally:
+        # Kill the query so the test doesn't hang
+        try:
+            admin.kill_query(query_id)
+        except Exception:
+            pass
+        t.join(timeout=10)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -2,7 +2,13 @@ import pytest
 import threading
 import uuid
 
-from stardog import admin as admin_module, connection, content, content_types, exceptions
+from stardog import (
+    admin as admin_module,
+    connection,
+    content,
+    content_types,
+    exceptions,
+)
 
 
 def starwars_contents() -> list:
@@ -856,7 +862,9 @@ def test_update_with_query_id(admin, db, conn: connection.Connection):
 
 @pytest.mark.dbname("pystardog-test-database")
 @pytest.mark.conn_dbname("pystardog-test-database")
-def test_query_id_visible_in_running_queries(admin, db, conn: connection.Connection, conn_string):
+def test_query_id_visible_in_running_queries(
+    admin, db, conn: connection.Connection, conn_string
+):
     """Verify that a custom query_id is visible via the admin running queries API."""
     query_id = f"pystardog-test-{uuid.uuid4()}"
 
@@ -880,7 +888,9 @@ def test_query_id_visible_in_running_queries(admin, db, conn: connection.Connect
     def slow_query():
         try:
             # Use a separate connection so we don't interfere with the main one
-            with connection.Connection("pystardog-test-database", **conn_string) as bg_conn:
+            with connection.Connection(
+                "pystardog-test-database", **conn_string
+            ) as bg_conn:
                 bg_conn.select(
                     "SELECT * WHERE { ?a ?b ?c . ?d ?e ?f . ?g ?h ?i . ?j ?k ?l }",
                     query_id=query_id,

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -358,42 +358,6 @@ class TestContent:
             m = content.MappingRaw(f.read())
             assert m.syntax is None
 
-
-class TestConnectionQueryId:
-    def test_select_query_id_is_sent_as_request_id_param(self):
-        def text_callback(request, context):
-            assert request.path == "/test/query"
-            assert request.qs["id"] == ["query-123"]
-            context.headers["Content-Type"] = content_types.SPARQL_JSON
-            return '{"head":{"vars":[]},"results":{"bindings":[]}}'
-
-        with requests_mock.Mocker() as m:
-            m.post(
-                "http://localhost:5820/test/query",
-                text=text_callback,
-            )
-
-            conn = connection.Connection("test")
-            result = conn.select("select * where { ?s ?p ?o }", query_id="query-123")
-
-        assert result["results"]["bindings"] == []
-
-    def test_update_query_id_is_sent_as_request_id_param(self):
-        def text_callback(request, context):
-            assert request.path == "/test/update"
-            assert request.qs["id"] == ["update-123"]
-            context.status_code = 200
-            return ""
-
-        with requests_mock.Mocker() as m:
-            m.post(
-                "http://localhost:5820/test/update",
-                text=text_callback,
-            )
-
-            conn = connection.Connection("test")
-            conn.update("delete where { ?s ?p ?o }", query_id="update-123")
-
         m = content.MappingRaw("does not matter", name="mapping.sms2")
         assert m.syntax == "SMS2"
         assert m.name == "mapping.sms2"
@@ -494,6 +458,57 @@ class TestConnectionQueryId:
         assert m.input_type is None
         assert m.name == "test.what"
         assert m.separator is None
+
+
+class TestConnectionQueryId:
+    def test_select_query_id_is_sent_as_url_param(self):
+        def text_callback(request, context):
+            assert request.path == "/test/query"
+            assert request.qs["id"] == ["query-123"]
+            context.headers["Content-Type"] = content_types.SPARQL_JSON
+            return '{"head":{"vars":[]},"results":{"bindings":[]}}'
+
+        with requests_mock.Mocker() as m:
+            m.post(
+                "http://localhost:5820/test/query",
+                text=text_callback,
+            )
+
+            conn = connection.Connection("test")
+            result = conn.select("select * where { ?s ?p ?o }", query_id="query-123")
+
+        assert result["results"]["bindings"] == []
+
+    def test_update_query_id_is_sent_as_url_param(self):
+        def text_callback(request, context):
+            assert request.path == "/test/update"
+            assert request.qs["id"] == ["update-123"]
+            context.status_code = 200
+            return ""
+
+        with requests_mock.Mocker() as m:
+            m.post(
+                "http://localhost:5820/test/update",
+                text=text_callback,
+            )
+
+            conn = connection.Connection("test")
+            conn.update("delete where { ?s ?p ?o }", query_id="update-123")
+
+    def test_query_id_not_sent_when_not_provided(self):
+        def text_callback(request, context):
+            assert "id" not in request.qs
+            context.headers["Content-Type"] = content_types.SPARQL_JSON
+            return '{"head":{"vars":[]},"results":{"bindings":[]}}'
+
+        with requests_mock.Mocker() as m:
+            m.post(
+                "http://localhost:5820/test/query",
+                text=text_callback,
+            )
+
+            conn = connection.Connection("test")
+            conn.select("select * where { ?s ?p ?o }")
 
 
 class TestStardogException:

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 import requests_mock
 
-from stardog import admin, content, exceptions, content_types
+from stardog import admin, content, exceptions, content_types, connection
 
 
 class TestMaterializeGraph:
@@ -357,6 +357,42 @@ class TestContent:
         with open("test/data/r2rml.ttl") as f:
             m = content.MappingRaw(f.read())
             assert m.syntax is None
+
+
+class TestConnectionQueryId:
+    def test_select_query_id_is_sent_as_request_id_param(self):
+        def text_callback(request, context):
+            assert request.path == "/test/query"
+            assert request.qs["id"] == ["query-123"]
+            context.headers["Content-Type"] = content_types.SPARQL_JSON
+            return '{"head":{"vars":[]},"results":{"bindings":[]}}'
+
+        with requests_mock.Mocker() as m:
+            m.post(
+                "http://localhost:5820/test/query",
+                text=text_callback,
+            )
+
+            conn = connection.Connection("test")
+            result = conn.select("select * where { ?s ?p ?o }", query_id="query-123")
+
+        assert result["results"]["bindings"] == []
+
+    def test_update_query_id_is_sent_as_request_id_param(self):
+        def text_callback(request, context):
+            assert request.path == "/test/update"
+            assert request.qs["id"] == ["update-123"]
+            context.status_code = 200
+            return ""
+
+        with requests_mock.Mocker() as m:
+            m.post(
+                "http://localhost:5820/test/update",
+                text=text_callback,
+            )
+
+            conn = connection.Connection("test")
+            conn.update("delete where { ?s ?p ?o }", query_id="update-123")
 
         m = content.MappingRaw("does not matter", name="mapping.sms2")
         assert m.syntax == "SMS2"


### PR DESCRIPTION
Implement query_id for select/update queries and add unit tests for that.

Jira ticket: https://stardog.atlassian.net/browse/PLAT-8865

I tested this by running the unit tests I added and by running a long-running query against my local endpoint and then using `admin.query(query_id)` to see if I could get a status back. A snippet of the script I used for the latter:
```python
info = admin.query(query_id)
status = info.get("status", info)
print("status:", status)
```
The status I got back for the read query was `PRE-EXEC`, presumably just because I hit it quickly, and for the update query I got `RUNNING`. Both are those indicate success to me.