### PR TITLE
PLAT-8866: expose process management functionality

### DIFF
--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -5,7 +5,7 @@
 import json
 import urllib
 from time import sleep
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, TypedDict, Union
 
 import contextlib
 from requests.auth import AuthBase
@@ -16,6 +16,16 @@ from . import content_types as content_types
 from .http import client
 
 DEFAULT_MAPPINGS_SYNTAX = "SMS"
+
+
+class ProcessInfo(TypedDict):
+    type: str
+    db: str
+    endTime: int
+    startTime: int
+    id: str
+    user: str
+    status: str
 
 
 class Admin:
@@ -278,30 +288,30 @@ class Admin:
         """
         self.client.delete("/admin/queries/{}".format(id))
 
-    def process(self, id: str) -> Dict:
-        """Gets information about a running process.
+    def process(self, id: str) -> ProcessInfo:
+        """Gets information about a process.
 
         :param id: Process ID
 
         :return: Process information
         """
-        r = self.client.get("/admin/processes/{}".format(id))
+        r = self.client.get(f"/admin/processes/{id}")
         return r.json()
 
-    def processes(self) -> List[Dict]:
-        """Gets information about all running processes.
+    def processes(self) -> List[ProcessInfo]:
+        """Gets information about all processes.
 
-        :return: information about all running processes
+        :return: information about all processes
         """
         r = self.client.get("/admin/processes")
         return r.json()
 
     def kill_process(self, id: str) -> None:
-        """Kills a running process.
+        """Kills a process.
 
         :param id: ID of the process to kill
         """
-        self.client.delete("/admin/processes/{}".format(id))
+        self.client.delete(f"/admin/processes/{id}")
 
     def stored_query(self, name: str) -> "StoredQuery":
         """Retrieves a Stored Query.

--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -278,6 +278,31 @@ class Admin:
         """
         self.client.delete("/admin/queries/{}".format(id))
 
+    def process(self, id: str) -> Dict:
+        """Gets information about a running process.
+
+        :param id: Process ID
+
+        :return: Process information
+        """
+        r = self.client.get("/admin/processes/{}".format(id))
+        return r.json()
+
+    def processes(self) -> List[Dict]:
+        """Gets information about all running processes.
+
+        :return: information about all running processes
+        """
+        r = self.client.get("/admin/processes")
+        return r.json()
+
+    def kill_process(self, id: str) -> None:
+        """Kills a running process.
+
+        :param id: ID of the process to kill
+        """
+        self.client.delete("/admin/processes/{}".format(id))
+
     def stored_query(self, name: str) -> "StoredQuery":
         """Retrieves a Stored Query.
 

--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -298,7 +298,7 @@ class Admin:
         r = self.client.get(f"/admin/processes/{id}")
         return r.json()
 
-    def processes(self) -> List[ProcessInfo]:
+    def processes(self) -> list[ProcessInfo]:
         """Gets information about all processes.
 
         :return: information about all processes

--- a/test/test_server_admin.py
+++ b/test/test_server_admin.py
@@ -32,6 +32,16 @@ def test_queries(admin):
         admin.kill_query(1)
 
 
+def test_processes(admin):
+    assert len(admin.processes()) == 0
+
+    with pytest.raises(exceptions.StardogException, match="Process not found: 1"):
+        admin.process(1)
+
+    with pytest.raises(exceptions.StardogException, match="Process not found: 1"):
+        admin.kill_process(1)
+
+
 ## This might or might not be better to move it to a separate file.
 ## Since we move to machine executor, we don't really need to ssh, since we can modify the files on the host
 @pytest.mark.skip(

--- a/test/test_server_admin.py
+++ b/test/test_server_admin.py
@@ -1,5 +1,8 @@
+import threading
+import time
+
 import pytest
-from stardog import exceptions
+from stardog import connection, content, content_types, exceptions
 
 
 def test_get_server_metrics(admin):
@@ -40,6 +43,76 @@ def test_processes(admin):
 
     with pytest.raises(exceptions.StardogException, match="Process not found: 1"):
         admin.kill_process(1)
+
+
+@pytest.mark.dbname("pystardog-test-database")
+def test_processes_while_running(admin, conn_string, db):
+    seed = "@prefix ex: <http://example.com/> .\n" + "\n".join(
+        f"ex:s{i} ex:p ex:o{i} ." for i in range(1, 80)
+    )
+    update = """
+    prefix ex: <http://example.com/>
+
+    insert {
+      ?s1 ex:derived ?o3 .
+    }
+    where {
+      ?s1 ?p1 ?o1 .
+      ?s2 ?p2 ?o2 .
+      ?s3 ?p3 ?o3 .
+    }
+    """
+
+    with connection.Connection(db.name, **conn_string) as conn:
+        conn.begin()
+        conn.clear()
+        conn.add(content.Raw(seed, content_types.TURTLE))
+        conn.commit()
+
+    update_done = threading.Event()
+    update_errors = []
+
+    def run_update():
+        try:
+            with connection.Connection(db.name, **conn_string) as conn:
+                conn.update(update)
+        except exceptions.StardogException as exc:
+            update_errors.append(exc)
+        finally:
+            update_done.set()
+
+    worker = threading.Thread(target=run_update)
+    worker.start()
+
+    process = None
+    deadline = time.time() + 10
+    while time.time() < deadline and process is None:
+        processes = admin.processes()
+        for candidate in processes:
+            if candidate.get("db") != db.name:
+                continue
+            if candidate.get("type") == "Transaction":
+                process = candidate
+                break
+            if process is None:
+                process = candidate
+        if process is None:
+            time.sleep(0.2)
+
+    assert process is not None
+    assert process["status"] == "RUNNING"
+
+    details = admin.process(process["id"])
+    assert details["id"] == process["id"]
+    assert details["db"] == db.name
+    assert details["status"] == "RUNNING"
+
+    admin.kill_process(process["id"])
+
+    worker.join(timeout=10)
+    assert update_done.is_set()
+    assert update_errors
+    assert "cancel" in str(update_errors[0]).lower()
 
 
 ## This might or might not be better to move it to a separate file.


### PR DESCRIPTION
Add functions for `process`, `processes`, and `kill`. 

I added a unit test for each that checked the expect output when no processes were running and an integration test that starts a long transaction, checks the running processes, grabs a running process, and then kills it.

---
I cherry-picked my CI commits from [here](https://github.com/stardog-union/pystardog/pull/197/) so the tests would pass.