### PR TITLE
fix: send mappings.syntax on virtual graph update (PLAT-9239)

### DIFF
--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -1714,7 +1714,7 @@ class VirtualGraph:
         self,
         name: str,
         mappings: Content,
-        options: dict = {},
+        options: Optional[dict] = None,
         datasource: Optional[str] = None,
         db: Optional[str] = None,
     ) -> None:
@@ -1722,7 +1722,10 @@ class VirtualGraph:
 
         :param name: The new name
         :param mappings: New mapping contents
-        :param options: New virtual graph options
+        :param options: New virtual graph options. If the ``mappings`` carry a
+            syntax (e.g. :class:`stardog.content.MappingFile` or
+            :class:`stardog.content.MappingRaw`), ``mappings.syntax`` is added
+            automatically unless explicitly provided here.
         :param datasource: new data source for the virtual graph
         :param db: the database to associate with the virtual graph
 
@@ -1736,6 +1739,15 @@ class VirtualGraph:
                     options={'jdbc.driver': 'com.mysql.jdbc.Driver'}
             )
         """
+        # copy so we never mutate the caller's dict
+        options = dict(options) if options else {}
+
+        # Without an explicit syntax the server falls back to auto-detection and
+        # stores a re-parsed form of the mapping, which does not round-trip (see
+        # PLAT-9239). new_virtual_graph() already sends this; update() must too.
+        if mappings and getattr(mappings, "syntax", None):
+            options.setdefault("mappings.syntax", mappings.syntax)
+
         if mappings:
             with mappings.data() as data:
                 mappings = data.read().decode() if hasattr(data, "read") else data
@@ -1743,8 +1755,7 @@ class VirtualGraph:
         meta = {}
         meta["name"] = name
         meta["mappings"] = mappings
-        if options is not None:
-            meta["options"] = options
+        meta["options"] = options
 
         if datasource is not None:
             meta["data_source"] = datasource

--- a/test/data/plat9239_blanknodes.sms2
+++ b/test/data/plat9239_blanknodes.sms2
@@ -1,0 +1,25 @@
+PREFIX : <http://api.stardog.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+MAPPING <urn:albumProvenance>
+FROM SQL {
+  SELECT `al`.`id`, `al`.`name`, `al`.`release_date`, `ar`.`name` AS `artist_name`
+  FROM `music`.`Album` `al`
+  JOIN `music`.`Artist` `ar` ON `al`.`artist` = `ar`.`id`
+}
+TO {
+  ?album rdf:type :Album ;
+         :title ?name ;
+         :hasProvenance ?prov .
+  ?prov rdf:type :ProvenanceRecord ;
+        :releaseDate ?release_date ;
+        :attributedTo ?agent .
+  ?agent rdf:type :Agent ;
+         :agentName ?artist_name .
+}
+WHERE {
+  # the album subject is templated from the primary key
+  BIND(TEMPLATE("http://api.stardog.com/album/{id}") AS ?album)
+  BIND(TEMPLATE("_:prov{id}") AS ?prov)
+  BIND(TEMPLATE("_:agent{id}") AS ?agent)
+}

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -522,3 +522,163 @@ class TestStardogException:
         assert str(exception) == "Mymessage"
         assert exception.http_code == 400
         assert exception.stardog_code == "SD90A"
+
+
+class TestVirtualGraphUpdate:
+    """Regression tests for PLAT-9239.
+
+    ``VirtualGraph.update()`` used to drop the mapping's syntax, sending
+    ``options: {}``. Without an explicit ``mappings.syntax`` the server
+    auto-detects, re-parses and stores a rewritten form of the mapping (mapping
+    IDs renumbered, blocks split, variables renamed, comments stripped), so the
+    mapping no longer round-trips. ``new_virtual_graph()`` has always sent it.
+    """
+
+    VG_PATH = "http://localhost:5820/admin/virtual_graphs/machineKG"
+    FIXTURE = "test/data/plat9239_blanknodes.sms2"
+
+    def _admin_and_vg(self, m):
+        m.get("http://localhost:5820/admin/alive", status_code=200)
+        m.get(self.VG_PATH, status_code=200, json={})
+        m.get(f"{self.VG_PATH}/info", status_code=200, json={"info": {}})
+        m.put(self.VG_PATH, status_code=200, json={})
+        sd_admin = admin.Admin("http://localhost:5820", "admin", "admin")
+        return admin.VirtualGraph("machineKG", sd_admin.client)
+
+    @staticmethod
+    def _last_put(m):
+        for request in reversed(m.request_history):
+            if request.method == "PUT":
+                return request.json()
+        raise AssertionError("no PUT request was captured")
+
+    def test_update_sends_mapping_syntax_from_file(self):
+        with requests_mock.Mocker() as m:
+            vg = self._admin_and_vg(m)
+            vg.update(
+                name="machineKG",
+                mappings=content.MappingFile(self.FIXTURE),
+                datasource="ds_test",
+                db="db_test",
+            )
+            body = self._last_put(m)
+
+        assert body["options"] == {"mappings.syntax": "SMS2"}
+
+    def test_update_sends_mapping_syntax_from_raw(self):
+        with open(self.FIXTURE, "rb") as f:
+            raw = f.read().decode()
+
+        with requests_mock.Mocker() as m:
+            vg = self._admin_and_vg(m)
+            vg.update(
+                name="machineKG",
+                mappings=content.MappingRaw(raw, "SMS2"),
+                datasource="ds_test",
+                db="db_test",
+            )
+            body = self._last_put(m)
+
+        assert body["options"] == {"mappings.syntax": "SMS2"}
+
+    def test_update_transmits_mapping_verbatim(self):
+        """CRLF line endings and comments must survive untouched."""
+        with open(self.FIXTURE, "rb") as f:
+            original = f.read().decode()
+
+        with requests_mock.Mocker() as m:
+            vg = self._admin_and_vg(m)
+            vg.update(
+                name="machineKG",
+                mappings=content.MappingFile(self.FIXTURE),
+                datasource="ds_test",
+                db="db_test",
+            )
+            body = self._last_put(m)
+
+        assert body["mappings"] == original
+        assert "\r\n" in body["mappings"]
+        assert (
+            "# the album subject is templated from the primary key" in body["mappings"]
+        )
+
+    def test_update_does_not_override_caller_supplied_syntax(self):
+        with requests_mock.Mocker() as m:
+            vg = self._admin_and_vg(m)
+            vg.update(
+                name="machineKG",
+                mappings=content.MappingFile(self.FIXTURE),
+                options={"mappings.syntax": "STARDOG"},
+                datasource="ds_test",
+                db="db_test",
+            )
+            body = self._last_put(m)
+
+        assert body["options"]["mappings.syntax"] == "STARDOG"
+
+    def test_update_preserves_other_caller_options(self):
+        with requests_mock.Mocker() as m:
+            vg = self._admin_and_vg(m)
+            vg.update(
+                name="machineKG",
+                mappings=content.MappingFile(self.FIXTURE),
+                options={"percent.encode": "false"},
+                datasource="ds_test",
+                db="db_test",
+            )
+            body = self._last_put(m)
+
+        assert body["options"] == {
+            "percent.encode": "false",
+            "mappings.syntax": "SMS2",
+        }
+
+    def test_update_does_not_mutate_caller_options(self):
+        caller_options = {"percent.encode": "false"}
+
+        with requests_mock.Mocker() as m:
+            vg = self._admin_and_vg(m)
+            vg.update(
+                name="machineKG",
+                mappings=content.MappingFile(self.FIXTURE),
+                options=caller_options,
+                datasource="ds_test",
+                db="db_test",
+            )
+
+        assert caller_options == {"percent.encode": "false"}
+
+    def test_update_does_not_leak_options_between_calls(self):
+        """The old mutable default (``options: dict = {}``) would leak."""
+        with requests_mock.Mocker() as m:
+            vg = self._admin_and_vg(m)
+            vg.update(
+                name="machineKG",
+                mappings=content.MappingFile(self.FIXTURE),
+                options={"percent.encode": "false"},
+                datasource="ds_test",
+                db="db_test",
+            )
+            vg.update(
+                name="machineKG",
+                mappings=content.MappingRaw("MAPPING\nFROM SQL {}", "STARDOG"),
+                datasource="ds_test",
+                db="db_test",
+            )
+            body = self._last_put(m)
+
+        assert body["options"] == {"mappings.syntax": "STARDOG"}
+
+    def test_update_omits_syntax_when_mapping_has_none(self):
+        """Plain ``File`` content carries no syntax; don't invent one."""
+        with requests_mock.Mocker() as m:
+            vg = self._admin_and_vg(m)
+            vg.update(
+                name="machineKG",
+                mappings=content.Raw("@prefix : <http://example.org/> .", name="m.ttl"),
+                datasource="ds_test",
+                db="db_test",
+            )
+            body = self._last_put(m)
+
+        assert "mappings.syntax" not in body["options"]


### PR DESCRIPTION
Fixes [PLAT-9239](https://stardog.atlassian.net/browse/PLAT-9239).

## Problem

`VirtualGraph.update()` discarded the mapping's syntax and PUT an empty `options` dict, while `Admin.new_virtual_graph()` has always copied `mappings.syntax` into `options`. Without an explicit syntax the server falls back to auto-detection and stores a re-parsed form of the mapping rather than accepting it as-is.

Captured request bodies, using a blank-node SMS2 mapping with CRLF line endings:

| call | `options` sent |
| --- | --- |
| `new_virtual_graph(...)` | `{"mappings.syntax": "SMS2"}` |
| `VirtualGraph.update(...)` | `{}` |
| `update()` with `MappingRaw(raw, "SMS2")` | `{}` — explicit syntax on the object discarded too |

The mapping text itself was byte-identical in every case, CRLF and comments intact, so pystardog never mangles the content.

This is not a regression — `update()` has been missing the syntax since the method was introduced.

## Effect on the stored mapping

Verified against a real Stardog 12.0.3. Fetching `mappingsString/SMS2` after create and again after an update, the two diverged badly: `<urn:albumProvenance>` became `_0`/`_1`/`_2`, one `MAPPING` block was split into three, `?prov` → `?subject` and `?artist_name` → `?name0`, the comment was stripped, `SELECT` lists were rewritten, and 7 prefixes were injected. This matches the mangled mapping the customer attached to the ticket.

After this change the two are byte-identical.

## Scope note on triple loss

The ticket reports *missing triples*. That specific symptom did **not** reproduce here — querying the virtual graph before and after the lossy update returned 24 triples both times with identical predicate counts, so the rewrite is structural rather than lossy on 12.0.3.

The inline `[ ... ]` blank-node form was also rejected outright (`Unknown field: _anon_1`) whether or not the syntax was declared, so that isn't the mechanism either. Only `BIND(TEMPLATE("_:prov{id}") AS ?prov)` is accepted.

This PR fixes the mapping-rewrite defect, which is real and explains the altered mapping text the customer observed. Confirming whether their mapping additionally loses triples likely needs their original file.

## Known related issue, not fixed here

`update()` also wipes every previously-set virtual graph option — setting `mappings.syntax` and `percent.encode` at create time and then calling `update()` leaves `options()` returning `{}`. Omitting the `options` key entirely does not help; the PUT is full-replace server-side, so preserving options requires the client to send them (as `update()` already does for `data_source` and `db`). That is a broader semantic change than this fix and is left for a separate ticket.

## Implementation

- Inject `mappings.syntax` from the mapping object, via `setdefault` so an explicit caller value always wins.
- `options: dict = {}` → `Optional[dict] = None`, and copy rather than mutate the caller's dict.

The syntax is injected **only when the mapping object carries one**, deliberately not mirroring `new_virtual_graph()`'s fallback to `DEFAULT_MAPPINGS_SYNTAX` (`'SMS'`). Copying that fallback would start stamping `SMS` onto callers passing plain `File('mappings.ttl')`, who today rely on server-side auto-detection.

## Testing

- 8 new tests in `TestVirtualGraphUpdate`. 4 of them fail without the fix and all 8 pass with it (verified by stashing the change).
- New fixture `test/data/plat9239_blanknodes.sms2` with real CRLF endings and a comment-then-BIND line. It needed `git add -f`, since `.gitignore` has a bare `data` rule that ignores new files under `test/data/`.
- Full suite against live Stardog 12.0.3: 121 passed, 7 skipped.
- `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PLAT-9239]: https://stardog.atlassian.net/browse/PLAT-9239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ