### PR TITLE
ci: pin STARDOG_TAG to 12.0.4 to unbreak integration jobs

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,10 @@
 # Stardog version tag
+# Pinned deliberately: the 12.1.x images moved from an Ubuntu base to a
+# Chainguard/Wolfi base, which has no apt-get, so dockerfile-stardog fails to
+# build against them. 12.0.4 is the newest Ubuntu-based release. Unpinning
+# requires porting dockerfile-stardog to Wolfi first.
 STARDOG_REPO=stardog/stardog
-STARDOG_TAG=latest
+STARDOG_TAG=12.0.4
 STARDOG_USER=admin
 STARDOG_PASS=admin
 


### PR DESCRIPTION
## Problem

Both integration jobs have been failing before a single test runs, during the docker build of the Stardog test image:

```
=> ERROR [project-sd-single-node 3/10] RUN apt-get update -y && apt-get install openssh-server vim unzip wget -y
#0 0.217 /bin/sh: apt-get: not found
Exited with code exit status 17
```

`.env` set `STARDOG_TAG=latest` — a floating tag. Stardog's container base image changed from **Ubuntu 22.04** to **Chainguard/Wolfi** in the 12.1.x line, and Wolfi ships `apk` rather than `apt-get`, so line 7 of `dockerfiles/dockerfile-stardog` can no longer run.

Confirmed from the registry image configs:

| tag | published | base | `apt-get` |
| --- | --- | --- | --- |
| 12.0.3 | 2026-05-12 | Ubuntu 22.04 | present |
| 12.0.4 | 2026-06-15 | Ubuntu 22.04 | present |
| 12.1.0 | 2026-06-10 | Chainguard (builder `apko`) | **missing** |
| 12.1.1 | 2026-07-02 | Chainguard | **missing** |
| 12.1.2 | 2026-08-04 | Chainguard | **missing** ← `latest` |

## Why now

The last green integration run was **2026-05-18** (builds 1783/1785), when `latest` still resolved to 12.0.3. Nothing was pushed between then and 2026-08-19, so the first build to inherit the new base image was also the first to fail.

This means the red CI on #202 is **not** caused by that PR — any commit pushed to this repo since ~2026-06-10 fails identically. This PR is split out so the CI fix can land independently.

## Fix

Pin to `12.0.4`, the newest Ubuntu-based release.

Pinning is the right end state regardless of the base-image change: a floating tag means an upstream image release can break CI on an unrelated PR, which is exactly what happened here. The ZooKeeper image in the same file is already pinned this way.

## Verification

Probed both images directly (`--platform linux/amd64`, since 12.0.x is amd64-only and CI runs amd64):

```
12.0.4 -> os: Ubuntu 22.04.5 LTS   apt-get: /usr/bin/apt-get   unzip: /usr/bin/unzip
12.1.2 -> os: Chainguard           apt-get: MISSING            apk: /usr/bin/apk
```

So the failing `apt-get` line works again under this pin.

## Tradeoff / follow-up

CI no longer exercises 12.1.x until `dockerfile-stardog` is ported to Wolfi. That port is more than swapping `apt-get` for `apk` — tested inside `stardog/stardog:12.1.2`:

- `apk add --no-cache openssh-server unzip wget` **succeeds**, so a package manager is available
- `ssh-keygen -t dsa` (dockerfile line 30, plus the matching `HostKey` on line 33) **fails** — `unknown key type dsa`. DSA was removed in OpenSSH 9.8+; Wolfi ships OpenSSH 10.5p1. `rsa`, `ecdsa`, `ed25519` all work
- `Subsystem sftp /usr/lib/ssh/sftp-server` (line 37) — that path does not exist, and `openssh-server` alone ships no `sftp-server` binary; it needs a separate package
- `sshd` lands at `/usr/bin/sshd`, not `/usr/sbin/sshd`

Worth its own ticket rather than blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)