### PR TITLE
ci: port dockerfile-stardog to the Chainguard/Wolfi base, pin to 12.1.2

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,9 @@
 # Stardog version tag
+# Pinned rather than floating: an upstream image release should not be able to
+# break CI on an unrelated PR, which is what happened when the 12.1.x images
+# moved to a Chainguard/Wolfi base. dockerfile-stardog targets that base.
 STARDOG_REPO=stardog/stardog
-STARDOG_TAG=latest
+STARDOG_TAG=12.1.2
 STARDOG_USER=admin
 STARDOG_PASS=admin
 

--- a/dockerfiles/dockerfile-stardog
+++ b/dockerfiles/dockerfile-stardog
@@ -4,13 +4,13 @@ FROM ${STARDOG_REPO}:${STARDOG_TAG}
 
 USER root
 RUN yes $SSH_PASS | passwd $SSH_USER
-RUN apt-get update -y && apt-get install openssh-server vim unzip wget -y
+RUN apk add --no-cache openssh-server openssh-sftp-server vim unzip wget
 
 ARG CONNECTOR_VERSION=8.0.21
 
 RUN wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${CONNECTOR_VERSION}.zip \
   && unzip mysql-connector-java-${CONNECTOR_VERSION}.zip \
-  && mv mysql-connector-java-${CONNECTOR_VERSION}/mysql-connector-java-${CONNECTOR_VERSION}.jar opt/stardog/server/dbms/mysql-connector-java.jar
+  && mv mysql-connector-java-${CONNECTOR_VERSION}/mysql-connector-java-${CONNECTOR_VERSION}.jar /opt/stardog/server/dbms/mysql-connector-java.jar
 
 ARG NODE_TYPE
 ARG SSH_USER
@@ -27,10 +27,8 @@ USER stardog
 # make this easier in the future. We might still require ssh for tests that require restarting a stardog server.
 RUN mkdir ${HOME}/custom_ssh && \
     ssh-keygen -f ${HOME}/custom_ssh/ssh_host_rsa_key -N '' -t rsa && \
-    ssh-keygen -f ${HOME}/custom_ssh/ssh_host_dsa_key -N '' -t dsa && \
     echo -e "Port 2222 \n\
     HostKey ${HOME}/custom_ssh/ssh_host_rsa_key \n\
-    HostKey ${HOME}/custom_ssh/ssh_host_dsa_key \n\
     AuthorizedKeysFile  .ssh/authorized_keys \n\
     ChallengeResponseAuthentication no \n\
     UsePAM yes \n\

--- a/dockerfiles/start.sh
+++ b/dockerfiles/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
-/usr/sbin/sshd -f ${HOME}/custom_ssh/sshd_config -D -p 2222 &
+/usr/bin/sshd -f ${HOME}/custom_ssh/sshd_config -D -p 2222 &
 /opt/stardog/bin/stardog-admin server start
 tail -f /dev/null


### PR DESCRIPTION
Supersedes #203. Fixes [PLAT-9516](https://stardog.atlassian.net/browse/PLAT-9516).

## Problem

Both integration jobs have been failing before a single test runs, during the docker build of the Stardog test image:

```
=> ERROR [project-sd-single-node 3/10] RUN apt-get update -y && apt-get install openssh-server vim unzip wget -y
/bin/sh: apt-get: not found
Exited with code exit status 17
```

`.env` set `STARDOG_TAG=latest`. Stardog's container base image moved from **Ubuntu 22.04** to **Chainguard/Wolfi** in the 12.1.x line, and Wolfi ships `apk` rather than `apt-get`.

| tag | published | base |
| --- | --- | --- |
| 12.0.3 | 2026-05-12 | Ubuntu 22.04 |
| 12.0.4 | 2026-06-15 | Ubuntu 22.04 |
| 12.1.0 | 2026-06-10 | Chainguard (apko) |
| 12.1.1 | 2026-07-02 | Chainguard |
| 12.1.2 | 2026-08-04 | Chainguard ← `latest` |

Last green integration run was 2026-05-18, when `latest` still resolved to 12.0.3. Nothing was pushed between then and 2026-08-19, so the first build to inherit the new base image was also the first to fail — on an unrelated PR (#202).

## Approach

#203 pinned back to 12.0.4, the last Ubuntu-based release. That unbreaks CI but leaves us testing against a base image the product has moved off of, which is most of the value of an integration suite. This ports the Dockerfile instead and pins forward to 12.1.2.

Pinning is kept, just moved forward — a floating tag means an upstream image release can break CI on an arbitrary unrelated PR, which is exactly what happened.

## Changes

1. **`apt-get` → `apk`.** `openssh-sftp-server` is now requested explicitly: on Ubuntu the `sftp-server` binary came with `openssh-server`, on Wolfi it is a separate package. It installs to `/usr/lib/ssh/sftp-server` — the path the generated `sshd_config` already referenced, so no config change needed.

2. **Drop the DSA host key** (keygen line + its `HostKey` directive). DSA was removed in OpenSSH 9.8+; Wolfi ships 10.5p1, where `ssh-keygen -t dsa` fails with `unknown key type dsa`. Dead weight on any current base, not just Wolfi.

3. **`start.sh`: `/usr/sbin/sshd` → `/usr/bin/sshd`**, where the Wolfi package installs it.

4. **Absolute mysql-connector destination path.** It was relative (`opt/stardog/...`), which only resolved because the Ubuntu image's WORKDIR happened to be `/`. The Wolfi image sits at `/home/build`, so the relative path pointed at a nonexistent directory. This one only shows up in a real build, not by probing the image.

`ChallengeResponseAuthentication` and `UsePAM` in the generated config are deprecated but still accepted by OpenSSH 10.5 — `sshd -t` validates the generated config as-is, so they are left alone.

## Verification

Ran the real stack locally against 12.1.2, forced to `linux/amd64` to match CI.

**Single-node** — builds; server reports `12.1.2`; sshd running; connector jar in place:
```
126 passed, 8 skipped in 94.85s
```

**Cluster** — all images build including `sdcache1` (the one that failed in CI build 1786); cluster forms with a coordinator:
```
122 passed, 9 skipped, 1 failed in 205.33s
```

The single failure is `test_cluster.py::test_coordinator_check`, which resolves the coordinator to its internal docker bridge IP (`172.18.0.5:5820`) and connects to it. That is routable from CircleCI's Linux machine executor but not from a Docker Desktop for Mac host:

```
from macOS host:            HTTP 000 (unreachable)
from inside the network:    HTTP 200
```

An environment limitation of local verification, not a behavior change. It should pass in CI — worth a look at the cluster job to confirm.

## Not addressed here

Three pre-existing issues noticed while working, deliberately left alone to keep this reviewable:

- **`SSH_USER`/`SSH_PASS` are used on line 6 but not declared as `ARG` until lines 15-16**, so both are empty at that point. `yes` with no argument emits `y`, and `passwd` with no username targets the current user — so the line actually sets *root's* password to `y` rather than setting the stardog user's password. Harmless today, but not what it looks like.
- **The ssh apparatus serves tests that are skipped.** `test_backup_all` and friends are `@pytest.mark.skip` with the reason *"We need to sort out how we are going to deal with ssh, since it's no longer required"*. If that is settled, most of the ssh setup in this Dockerfile could go away entirely.
- **`test/test_unit.py:426`**: `assert (m.separator, ",")` asserts a tuple, so it is always true. Pytest flags it as `PytestAssertRewriteWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLAT-9516]: https://stardog.atlassian.net/browse/PLAT-9516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ