### PR TITLE
docs: read the version from package metadata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,8 +23,19 @@ project = "pystardog"
 copyright = "2019-2025 Stardog Union"
 author = "Stardog Union"
 
-# The short X.Y version
-version = "0.19.0"
+# The short X.Y version. Read from package metadata so that pyproject.toml stays
+# the single source of truth; falls back to reading pyproject.toml directly when
+# the docs are built from a source tree without pystardog installed.
+try:
+    from importlib.metadata import PackageNotFoundError, version as _package_version
+
+    version = _package_version("pystardog")
+except PackageNotFoundError:
+    import pathlib
+    import tomllib
+
+    _pyproject = pathlib.Path(__file__).resolve().parent.parent / "pyproject.toml"
+    version = tomllib.loads(_pyproject.read_text())["project"]["version"]
 # The full version, including alpha/beta/rc tags
 release = ""
 


### PR DESCRIPTION
`pyproject.toml` and `docs/conf.py` both carried a hardcoded version, and they had already diverged: `pyproject.toml` says `0.20.0` while `docs/conf.py` still says `0.19.0`, because the 0.20.0 release bumped one and not the other.

`conf.py` now reads the version from installed package metadata, making `pyproject.toml` the single source of truth.

### Why the fallback

Read the Docs installs the package before building (`.readthedocs.yaml` uses `method: pip, path: .`), so `importlib.metadata` always resolves there. The `tomllib` fallback covers building the docs from a source tree where pystardog isn't installed — `conf.py` puts the repo root on `sys.path`, so that's a real scenario for local builds.

### Verified

Both code paths were executed locally, and both return `0.20.0` — matching `pyproject.toml` rather than the stale `0.19.0`:

- metadata path: with pystardog installed
- fallback path: with `importlib.metadata.version` patched to raise `PackageNotFoundError`

Part of a small series moving releases onto CI. The other two PRs add a `CHANGELOG.md` and a release workflow; each stands alone and they can merge in any order.