### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to pystardog are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.21.0] - UNRELEASED
+
+### Added
+
+- **Process management on `Admin`.** Three new methods for inspecting and
+  cancelling server-side processes, backed by the `/admin/processes` endpoints
+  ([#198](https://github.com/stardog-union/pystardog/pull/198)):
+  - `Admin.process(id)` — information about a single process, as a `ProcessInfo`
+  - `Admin.processes()` — information about all running processes
+  - `Admin.kill_process(id)` — cancel a running process
+
+  A `ProcessInfo` `TypedDict` is now exported from `stardog.admin`, with the
+  fields `type`, `db`, `id`, `user`, `status`, `startTime`, and `endTime`.
+
+- **User-defined query IDs.** All query methods on `Connection` now accept an
+  optional `query_id` parameter, passed to the server as the query's `id`. This
+  makes a query traceable in the Stardog query log and cancellable through the
+  admin API without first having to discover the server-assigned ID
+  ([#197](https://github.com/stardog-union/pystardog/pull/197)):
+  `select()`, `graph()`, `paths()`, `ask()`, and `update()`.
+
+  ```python
+  conn.select("select * where { ?s ?p ?o }", query_id="nightly-audit-001")
+  ```
+
+### Fixed
+
+- **`VirtualGraph.update()` now sends `mappings.syntax`.** When updating a
+  virtual graph with mappings that carry a syntax (such as `MappingFile` or
+  `MappingRaw`), the syntax is now sent alongside the mappings. Previously it
+  was omitted, so the server fell back to auto-detection and stored a re-parsed
+  form of the mapping that did not round-trip. `new_virtual_graph()` already
+  sent this; `update()` now matches it. An explicit `mappings.syntax` in
+  `options` still wins (PLAT-9239,
+  [#202](https://github.com/stardog-union/pystardog/pull/202)).
+
+- **Mutable default argument in `VirtualGraph.update()`.** The `options`
+  parameter defaulted to a shared `{}` instance, which persisted across calls.
+  It now defaults to `None` and the caller's dict is copied rather than mutated
+  ([#202](https://github.com/stardog-union/pystardog/pull/202)).
+
+- **Incorrect return type annotation on `Admin.namespaces()`.** Annotated as
+  `Dict`, but pystardog unwraps the server's JSON object and returns a list. Now
+  annotated as `List`
+  ([#200](https://github.com/stardog-union/pystardog/pull/200)).
+
+### Changed
+
+- **Modernized type annotations in `stardog/admin.py`.** `typing.Dict` and
+  `typing.List` in return annotations were replaced with the builtin `dict` and
+  `list` generics. This is an annotation-only change with no runtime effect, and
+  the minimum supported Python version remains 3.9
+  ([#200](https://github.com/stardog-union/pystardog/pull/200)).
+
+### Internal
+
+These changes do not affect the published package.
+
+- Ported `dockerfiles/dockerfile-stardog` to the Chainguard/Wolfi base image,
+  pinned to Stardog 12.1.2
+  ([#204](https://github.com/stardog-union/pystardog/pull/204)).
+- Repaired failing CI tests around named graphs and `docs.size`
+  ([#199](https://github.com/stardog-union/pystardog/pull/199)).
+
+## [0.20.0] - 2026-03-18
+
+Released before this changelog was introduced. See the
+[commit history](https://github.com/stardog-union/pystardog/compare/0.19.0...0.20.0).
+
+## [0.19.0] - 2025-08-08
+
+Released before this changelog was introduced. See the
+[commit history](https://github.com/stardog-union/pystardog/compare/0.18.1...0.19.0).
+
+[Unreleased]: https://github.com/stardog-union/pystardog/compare/0.21.0...HEAD
+[0.21.0]: https://github.com/stardog-union/pystardog/compare/0.20.0...0.21.0
+[0.20.0]: https://github.com/stardog-union/pystardog/compare/0.19.0...0.20.0
+[0.19.0]: https://github.com/stardog-union/pystardog/compare/0.18.1...0.19.0


### PR DESCRIPTION
The repo has no changelog, so the only per-version record is GitHub's auto-generated release notes — a raw list of PR titles. Entries like "Bumping release version to 0.20.0" don't tell a user anything about what changed for them.

Seeds the file with the unreleased **0.21.0** entry, grouped by Added / Fixed / Changed, covering the 20 commits on `main` since the 0.20.0 tag:

- **Added** — process management on `Admin` (#198) and user-defined query IDs (#197)
- **Fixed** — the `mappings.syntax` fix from #202, and the `namespaces()` return annotation (#200)
- **Changed** — builtin `dict`/`list` generics in `admin.py` (#200), annotation-only, minimum Python stays 3.9
- **Internal** — Wolfi dockerfile port (#204) and CI repairs (#199), listed separately since they don't ship in the wheel

Earlier releases are stubbed with compare links rather than backfilled.

### Notes for review

- The 0.21.0 heading is marked `UNRELEASED`; whoever cuts the release renames it and adds the date.
- It credits #202 as fixed, which is still open. If that PR doesn't land before 0.21.0, drop those two entries.
- Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

Part of a small series moving releases onto CI. The other two PRs de-duplicate the version in `docs/conf.py` and add a release workflow; each stands alone and they can merge in any order.