### PR TITLE
ci: build on every PR, publish to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+# Builds the distribution on every PR, and publishes it to PyPI when a GitHub
+# Release is published.
+#
+# Publishing uses PyPI Trusted Publishing (OIDC) -- there is no API token stored
+# anywhere in this repository or in CI. PyPI's trusted publisher config for this
+# project references BOTH the filename of this workflow and the `pypi`
+# environment below. Renaming either will break publishing until the config on
+# PyPI is updated to match.
+#
+# CircleCI continues to run the test suite and static analysis; this workflow
+# only builds and publishes.
+
+name: release
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: twine check --strict dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: publish to PyPI
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pystardog
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # PyPI uploads are immutable and a version can never be reused, so this
+      # runs before the upload rather than as a post-hoc check.
+      - name: Verify release tag matches the package version
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          pkg="$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")"
+          echo "release tag: ${tag}"
+          echo "pyproject:   ${pkg}"
+          if [ "${tag}" != "${pkg}" ]; then
+            echo "::error::release tag ${tag} does not match pyproject.toml version ${pkg}"
+            exit 1
+          fi
+
+      # Publish the exact artifact that `build` produced and twine checked,
+      # rather than a second build that merely ought to be identical.
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -182,18 +182,58 @@ Example output after running ``make livehtml``:
     [I 230710 15:26:18 handlers:62] Start watching changes
     [I 230710 15:26:18 handlers:64] Start detecting changes
 
-Building and Publishing
------------------------
+Releasing
+---------
 
-To build and publish the package to PyPI:
+Releases are published to PyPI by the ``release`` GitHub Actions workflow
+(``.github/workflows/release.yml``) when a GitHub Release is published. The
+workflow uses `PyPI Trusted Publishing <https://docs.pypi.org/trusted-publishers/>`_,
+so there is no API token to hold, share, or rotate, and published artifacts carry
+provenance attestations.
+
+.. warning::
+
+    Do not run ``twine upload`` by hand. Doing so bypasses the version check and
+    the approval gate described below, and PyPI uploads are immutable -- a
+    version that has been published can never be replaced, only yanked.
+
+CircleCI continues to run the test suite and static analysis on every pull
+request. The GitHub Actions workflow only builds and publishes. Trusted
+publishing does not support CircleCI, which is why the release path lives in
+GitHub Actions rather than alongside the tests.
+
+Cutting a release
+^^^^^^^^^^^^^^^^^
+
+1. Update ``CHANGELOG.md``: rename the ``Unreleased`` section to the new version
+   and add today's date.
+2. Open a pull request bumping ``version`` in ``pyproject.toml``, and merge it.
+3. Draft a `GitHub Release <https://github.com/stardog-union/pystardog/releases/new>`_
+   against a new tag matching the version exactly, with no ``v`` prefix (for
+   example ``0.21.0``). Use that version's ``CHANGELOG.md`` section as the body.
+4. Review the draft, then publish it. Publishing starts the workflow.
+5. Approve the deployment when the ``pypi`` environment requests a reviewer. The
+   upload happens only after approval.
+
+The workflow verifies that the release tag matches the version in
+``pyproject.toml`` and fails before uploading if they disagree, so a mismatched
+tag costs a re-run rather than a bad release.
+
+Building locally
+^^^^^^^^^^^^^^^^
+
+To build and inspect the distribution without publishing it:
 
 .. code-block:: shell
 
     # Install build dependencies
     pip install -e ".[build]"
 
-    # Build the package
+    # Build the sdist and wheel
     python -m build
 
-    # Upload to PyPI (requires authentication)
-    twine upload dist/*
+    # Validate the package metadata
+    twine check --strict dist/*
+
+The ``release`` workflow runs these same steps on every pull request, so
+packaging problems surface during review rather than on release day.


### PR DESCRIPTION
Releases are currently built and uploaded by hand from a maintainer's laptop with a long-lived PyPI API token, as documented in `docs/contributing.rst`. Two problems follow from that, both visible in the release history:

- **The process drifts between releasers.** 0.15.0–0.19.0 shipped a wheel only; 0.20.0 shipped a wheel and an sdist. Nobody decided that.
- **Packaging is never exercised until release day.** CI runs tests and static analysis but never builds the distribution, so `python -m build` first runs at the moment someone is trying to ship.

### What this adds

A GitHub Actions workflow with two jobs:

- **`build`** — runs on every PR and push to `main`. Builds the sdist and wheel, validates metadata with `twine check --strict`, uploads the artifact. No secrets, no OIDC permissions.
- **`publish`** — runs only when a GitHub Release is published. Verifies the release tag matches `pyproject.toml`, then uploads the artifact `build` produced.

Publishing uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) over OIDC, so **no API token is stored in this repo or in CI**, and releases get PEP 740 provenance attestations (every pystardog release to date has none). The publish job runs in the `pypi` environment, which requires a reviewer's approval before anything reaches PyPI.

### Why GitHub Actions and not CircleCI

CircleCI is unchanged and keeps running the test suite and static analysis — this workflow only builds and publishes. PyPI's trusted publishing supports exactly four providers (GitHub Actions, GitLab CI/CD, Google Cloud, ActiveState) and CircleCI isn't one of them. Publishing from CircleCI would mean keeping a long-lived token in a context, which is the thing this removes. That reasoning is in a header comment in the workflow so it doesn't get lost.

### Docs

Rewrites the "Building and Publishing" section of `docs/contributing.rst`, which previously instructed maintainers to run `twine upload dist/*`. Following that after this merges would bypass both the version check and the approval gate, so it now documents the release flow instead and keeps the local build steps for inspecting a distribution.

### Verified locally

- `python -m build` produces both artifacts; `twine check --strict` PASSES on both.
- The tag-vs-version guard was run against three tags: `0.20.0` → pass, `0.99.0` → fail, `v0.20.0` → fail. That last case means it also enforces this repo's bare-tag convention.
- Workflow YAML parses; `docs/contributing.rst` parses through docutils with no warnings.

The `build` job running on this PR is itself the end-to-end proof — `publish` is skipped by `if: github.event_name == 'release'`.

### Before this can publish

The PyPI trusted publisher and the `pypi` environment are already configured. Note the workflow **filename** and the **environment name** are both referenced by PyPI's config — renaming either breaks publishing until PyPI is updated to match.

Part of a small series moving releases onto CI, alongside #205 and #206. Each stands alone and they can merge in any order.