### PR TITLE
test: stop asserting the server has zero processes

### DIFF
--- a/test/test_server_admin.py
+++ b/test/test_server_admin.py
@@ -36,7 +36,11 @@ def test_queries(admin):
 
 
 def test_processes(admin):
-    assert len(admin.processes()) == 0
+    # Do not assert this list is empty. The server runs its own managed
+    # processes (for example on the catalog database), so the count is not
+    # ours to control. test_processes_while_running covers the case where a
+    # specific process is expected, and filters by database to find it.
+    assert isinstance(admin.processes(), list)
 
     with pytest.raises(exceptions.StardogException, match="Process not found: 1"):
         admin.process(1)


### PR DESCRIPTION
`test_processes` opened with:

```python
assert len(admin.processes()) == 0
```

That is a claim about global server state, not about the code under test. Stardog runs its own managed processes, so the count isn't the test's to control.

### How it showed up

`basic_test_suite_single_node` failed on #205, #206 and #207 — including #206, which adds nothing but a markdown file. Within a single tox run, only py310 failed while py39, py311, py312 and py313 passed:

```
FAILED test/test_server_admin.py::test_processes - AssertionError: assert 2 == 0
>   assert len(admin.processes()) == 0
E   where 2 = len([{'db': 'catalog', 'id': '4340', ..., 'managed': True},
E                  {'db': 'catalog', 'id': '4397', ..., 'managed': True}])
```

Both processes are on the `catalog` database with `managed: True` — server-internal work, not test leftovers. Which Python env happens to observe them is arbitrary, which is why `main` is green and these PRs are red.

### The change

Asserts `processes()` returns a list instead. The assertions that follow — that an unknown process id raises on both `process()` and `kill_process()` — are what the test is actually for and are unchanged.

`test_processes_while_running` already handles the case where a specific process *is* expected, and correctly filters by database to find it. This makes `test_processes` consistent with that.

### Note on `test_queries`

`test_queries` has the same shape (`assert len(admin.queries()) == 0`) and I deliberately left it alone. Queries are user-initiated, so an idle server having none is a reasonable expectation; processes include server-managed ones, so zero is not. If it turns out to flake too, it needs the same treatment.

Unblocks the release series (#205, #206, #207) and #202, all of which are currently red on this test.