### PR TITLE
release: 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.21.0] - UNRELEASED
+## [0.21.0] - 2026-08-31
 
 ### Added
+
+- **Published via PyPI trusted publishing.** This release is built and uploaded
+  by GitHub Actions using OIDC, so no long-lived PyPI API token is stored
+  anywhere in the project. Releases now ship both a wheel and a source
+  distribution, and the uploaded artifacts carry
+  [PEP 740](https://peps.python.org/pep-0740/) provenance attestations
+  ([#207](https://github.com/stardog-union/pystardog/pull/207)).
 
 - **Process management on `Admin`.** Three new methods for inspecting and
   cancelling server-side processes, backed by the `/admin/processes` endpoints
@@ -60,16 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `list` generics. This is an annotation-only change with no runtime effect, and
   the minimum supported Python version remains 3.9
   ([#200](https://github.com/stardog-union/pystardog/pull/200)).
-
-### Internal
-
-These changes do not affect the published package.
-
-- Ported `dockerfiles/dockerfile-stardog` to the Chainguard/Wolfi base image,
-  pinned to Stardog 12.1.2
-  ([#204](https://github.com/stardog-union/pystardog/pull/204)).
-- Repaired failing CI tests around named graphs and `docs.size`
-  ([#199](https://github.com/stardog-union/pystardog/pull/199)).
 
 ## [0.20.0] - 2026-03-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pystardog"
-version = "0.20.0"
+version = "0.21.0"
 authors = [
     {name = "Stardog Union", email = "support@stardog.com"}
 ]


### PR DESCRIPTION
Version bump and changelog finalization for **0.21.0**. This is the last PR before tagging.

0.21.0 is a **minor** release: [#198](https://github.com/stardog-union/pystardog/pull/198) added `Admin.process`/`processes`/`kill_process` plus an exported `ProcessInfo` TypedDict, and [#197](https://github.com/stardog-union/pystardog/pull/197) added `query_id=` to `select`/`graph`/`paths`/`ask`/`update`.

## Changes

- `pyproject.toml`: `0.20.0` → `0.21.0`. Since [#205](https://github.com/stardog-union/pystardog/pull/205) landed, this is the only version source — `docs/conf.py` derives it from package metadata.
- `CHANGELOG.md`: dated the `0.21.0` section (was `UNRELEASED`).
- `CHANGELOG.md`: added an entry for PyPI trusted publishing ([#207](https://github.com/stardog-union/pystardog/pull/207)), which previously had no entry at all. This reads as user-facing rather than internal — the release ships both a wheel and an sdist, and the artifacts carry PEP 740 provenance attestations that a consumer can verify. Worded as a description of the mechanism rather than a claim about a specific artifact, since provenance is only confirmable after the upload.
- `CHANGELOG.md`: dropped the `### Internal` section. The base-image port ([#204](https://github.com/stardog-union/pystardog/pull/204)) and CI test repairs ([#199](https://github.com/stardog-union/pystardog/pull/199)) are not observable to anyone installing the package, and Keep a Changelog — which this file declares it follows — has no such category. Contributors are already served by the per-version compare links and the release's generated "What's Changed" list.

The two `### Fixed` entries for [#202](https://github.com/stardog-union/pystardog/pull/202) are retained, since it merged.

## Verification

- Both `docs/conf.py` code paths resolve to `0.21.0`: the `importlib.metadata` path (after refreshing the editable install) and the `tomllib` fallback.
- `python -m build` produces **both** artifacts — `pystardog-0.21.0-py3-none-any.whl` and `pystardog-0.21.0.tar.gz` — and `twine check --strict` passes on both.
- Full suite on merged `main` against live Stardog 12.1.2: **129 passed, 8 skipped**.
- Changelog self-consistency: section header matches the version, no `UNRELEASED` remaining, compare link ref present.

## After merge

1. Draft a GitHub Release against the bare tag `0.21.0` (no `v` prefix — the workflow's guard enforces this), body = the `0.21.0` changelog section.
2. Publish it; approve the `pypi` environment gate when it requests a reviewer.
3. Verify 0.21.0 on PyPI has both wheel and sdist and a non-null `provenance` via the simple API — it is `None` for every prior release, so a non-null value is the proof trusted publishing worked.
4. Revoke the old shared PyPI API token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
