### PR TITLE
[claude-auto] PLAT-8477: Disallow invalid IRIs in PyStardog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Graph URIs are now validated before a request is sent.** Every `Connection`,
+  `ICV` and `Admin` method that takes a graph URI now rejects values that are not
+  valid IRIs, raising `ValueError` instead of forwarding them to the server. The
+  reported case was `graph_uri='<urn:graph>'`, which previously created a graph
+  whose name contained the angle brackets (PLAT-8477,
+  [#212](https://github.com/stardog-union/pystardog/pull/212)).
+
+  This is a behaviour change in a public API. Values that used to reach the
+  server and now raise:
+
+  - anything containing a character the IRIREF grammar forbids — `<`, `>`, `"`,
+    `{`, `}`, `|`, `^`, `` ` ``, `\`, whitespace, or a control character
+  - relative names with no scheme, such as `'my-graph'`
+  - the empty string
+  - a list passed to the scalar `insert_graph_uri` or `remove_graph_uri`
+    parameters. Both are typed `Optional[str]`, so a list was never part of the
+    contract; it worked only because the value was forwarded to `requests`
+    unchecked. Use `using_graph_uri` or `using_named_graph_uri`, which are typed
+    `Optional[List[str]]`, where several graphs are genuinely intended.
+
+  Graphs already created with an invalid name are unaffected — the guard only
+  prevents new ones, and cleaning up existing names is out of scope. Note also
+  that this validates the pystardog client only: the same payload is still
+  accepted from any other HTTP client, so it does not close the underlying
+  server-side gap.
+
 ## [0.21.0] - 2026-08-31
 
 ### Added

--- a/stardog/admin.py
+++ b/stardog/admin.py
@@ -13,6 +13,7 @@ from requests.auth import AuthBase
 from stardog.content import Content, ImportFile, ImportRaw, MappingFile, MappingRaw
 
 from . import content_types as content_types
+from .utils import validate_iri
 from .http import client
 
 DEFAULT_MAPPINGS_SYNTAX = "SMS"
@@ -583,6 +584,7 @@ class Admin:
                 else:
                     mappings = data
 
+        validate_iri(named_graph)
         meta = {
             "db": db,
             "mappings": mappings,
@@ -711,6 +713,7 @@ class Admin:
         else:
             payload["options"] = ""
 
+        validate_iri(named_graph)
         if named_graph is not None:
             payload["named_graph"] = named_graph
 

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -12,7 +12,7 @@ from stardog.content import Content
 from . import content_types as content_types
 from . import exceptions as exceptions
 from .http import client
-from .utils import strtobool
+from .utils import strtobool, validate_iri
 import urllib
 
 
@@ -154,6 +154,8 @@ class Connection:
         Raises:
           stardog.exceptions.TransactionException
             If currently not in a transaction
+          ValueError
+            If ``graph_uri`` is not a valid IRI
 
         Examples:
 
@@ -168,6 +170,7 @@ class Connection:
 
         """
         self._assert_in_transaction()
+        validate_iri(graph_uri)
 
         args = {"params": {"graph-uri": graph_uri}}
 
@@ -198,12 +201,15 @@ class Connection:
         Raises:
           stardog.exceptions.TransactionException
             If currently not in a transaction
+          ValueError
+            If ``graph_uri`` is not a valid IRI
 
         Examples:
           >>> conn.remove(File('example.ttl'), graph_uri='urn:graph')
         """
 
         self._assert_in_transaction()
+        validate_iri(graph_uri)
 
         with content.data() as data:
             self.client.post(
@@ -238,6 +244,7 @@ class Connection:
           >>> conn.clear()
         """
         self._assert_in_transaction()
+        validate_iri(graph_uri)
         self.client.post(
             "/{}/clear".format(self.transaction), params={"graph-uri": graph_uri}
         )
@@ -286,6 +293,7 @@ class Connection:
           >>> with conn.export(stream=True) as stream:
                 contents = ''.join(stream)
         """
+        validate_iri(graph_uri)
 
         def _export():
             with self.client.get(
@@ -336,6 +344,18 @@ class Connection:
             "insert-graph-uri": kwargs.get("insert_graph_uri"),
             "schema": kwargs.get("schema"),
         }
+        for key in (
+            "default_graph_uri",
+            "named_graph_uri",
+            "using_graph_uri",
+            "using_named_graph_uri",
+        ):
+            uris = kwargs.get(key) or []
+            for uri in [uris] if isinstance(uris, str) else uris:
+                validate_iri(uri)
+        validate_iri(kwargs.get("remove_graph_uri"))
+        validate_iri(kwargs.get("insert_graph_uri"))
+
         request_params = {}
         query_id = kwargs.get("query_id")
         if query_id is not None:
@@ -672,6 +692,7 @@ class Connection:
         :param graph_uri: the URI of the graph to check
         :return: database consistency state
         """
+        validate_iri(graph_uri)
         r = self.client.get(
             "/reasoning/consistency",
             params={"graph-uri": graph_uri},
@@ -710,6 +731,7 @@ class Connection:
         :param graph_uri: the URI of the named graph for which to explain inconsistency
         :return: explanation results
         """
+        validate_iri(graph_uri)
         txId = self.transaction
         url = (
             "/reasoning/{}/explain/inconsistency".format(txId)
@@ -908,6 +930,7 @@ class ICV:
         Examples:
           >>> icv.is_valid(File('constraints.ttl'), graph_uri='urn:graph')
         """
+        validate_iri(graph_uri)
         transaction = self.conn.transaction
         url = "icv/{}/validate".format(transaction) if transaction else "/icv/validate"
         with content.data() as data:
@@ -940,6 +963,7 @@ class ICV:
           >>> icv.explain_violations(File('constraints.ttl'),
                                      graph_uri='urn:graph')
         """
+        validate_iri(graph_uri)
         transaction = self.conn.transaction
         url = (
             "/icv/{}/violations".format(transaction)
@@ -975,6 +999,7 @@ class ICV:
         Examples:
           >>> icv.convert(File('constraints.ttl'), graph_uri='urn:graph')
         """
+        validate_iri(graph_uri)
         with content.data() as data:
             r = self.client.post(
                 "/icv/convert",
@@ -1020,6 +1045,7 @@ class ICV:
         for arg in kwargs:
             if arg not in accepted_args:
                 raise Exception("Parameter not recognized")
+        validate_iri(kwargs.get("graph-uri"))
 
         kwargs["prettify"] = True
         params = urllib.parse.urlencode(kwargs)

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -242,6 +242,8 @@ class Connection:
           clear the whole database
 
           >>> conn.clear()
+
+    :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         self._assert_in_transaction()
         validate_iri(graph_uri)
@@ -292,6 +294,8 @@ class Connection:
 
           >>> with conn.export(stream=True) as stream:
                 contents = ''.join(stream)
+
+    :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
 
@@ -430,6 +434,8 @@ class Connection:
             :caption: Query utilizing ``bindings`` to bind the query variable ``o`` to a value of ``<urn:a>``.
 
             results = conn.select('select * {?s ?p ?o}', bindings={'o': '<urn:a>'})
+
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         return self.__query(
             query=query,
@@ -495,6 +501,8 @@ class Connection:
             :caption: ``CONSTRUCT`` (graph) query utilizing ``bindings`` to bind the query variable ``o`` to a value of ``<urn:a>``.
 
             results = conn.graph('select * {?s ?p ?o}', bindings={'o': '<urn:a>'})
+
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         return self.__query(
             query=query,
@@ -556,6 +564,7 @@ class Connection:
         See Also:
             `Stardog Docs - PATH Queries <https://docs.stardog.com/query-stardog/path-queries>`_
 
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         return self.__query(
             query=query,
@@ -613,6 +622,7 @@ class Connection:
         See Also:
             `SPARQL Spec - ASK Queries <https://www.w3.org/TR/sparql11-query/#ask>`_
 
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
 
         r = self.__query(
@@ -666,6 +676,8 @@ class Connection:
 
         Examples:
           >>> conn.update('delete where {?s ?p ?o}')
+
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
 
         self.__query(
@@ -691,6 +703,8 @@ class Connection:
 
         :param graph_uri: the URI of the graph to check
         :return: database consistency state
+
+    :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         r = self.client.get(
@@ -730,6 +744,8 @@ class Connection:
 
         :param graph_uri: the URI of the named graph for which to explain inconsistency
         :return: explanation results
+
+    :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         txId = self.transaction
@@ -929,6 +945,8 @@ class ICV:
 
         Examples:
           >>> icv.is_valid(File('constraints.ttl'), graph_uri='urn:graph')
+
+    :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         transaction = self.conn.transaction
@@ -962,6 +980,8 @@ class ICV:
         Examples:
           >>> icv.explain_violations(File('constraints.ttl'),
                                      graph_uri='urn:graph')
+
+    :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         transaction = self.conn.transaction
@@ -998,6 +1018,8 @@ class ICV:
 
         Examples:
           >>> icv.convert(File('constraints.ttl'), graph_uri='urn:graph')
+
+    :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         with content.data() as data:
@@ -1030,6 +1052,8 @@ class ICV:
 
         Examples:
           >>> icv.report()
+
+    :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
 
         accepted_args = [
@@ -1045,7 +1069,8 @@ class ICV:
         for arg in kwargs:
             if arg not in accepted_args:
                 raise Exception("Parameter not recognized")
-        validate_iri(kwargs.get("graph-uri"))
+        for name in ("graph-uri", "shapes", "shacl.shape.graphs", "nodes"):
+            validate_iri(kwargs.get(name))
 
         kwargs["prettify"] = True
         params = urllib.parse.urlencode(kwargs)

--- a/stardog/connection.py
+++ b/stardog/connection.py
@@ -243,7 +243,7 @@ class Connection:
 
           >>> conn.clear()
 
-    :raises ValueError: If a supplied graph URI is not a valid IRI.
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         self._assert_in_transaction()
         validate_iri(graph_uri)
@@ -295,7 +295,7 @@ class Connection:
           >>> with conn.export(stream=True) as stream:
                 contents = ''.join(stream)
 
-    :raises ValueError: If a supplied graph URI is not a valid IRI.
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
 
@@ -704,7 +704,7 @@ class Connection:
         :param graph_uri: the URI of the graph to check
         :return: database consistency state
 
-    :raises ValueError: If a supplied graph URI is not a valid IRI.
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         r = self.client.get(
@@ -745,7 +745,7 @@ class Connection:
         :param graph_uri: the URI of the named graph for which to explain inconsistency
         :return: explanation results
 
-    :raises ValueError: If a supplied graph URI is not a valid IRI.
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         txId = self.transaction
@@ -946,7 +946,7 @@ class ICV:
         Examples:
           >>> icv.is_valid(File('constraints.ttl'), graph_uri='urn:graph')
 
-    :raises ValueError: If a supplied graph URI is not a valid IRI.
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         transaction = self.conn.transaction
@@ -981,7 +981,7 @@ class ICV:
           >>> icv.explain_violations(File('constraints.ttl'),
                                      graph_uri='urn:graph')
 
-    :raises ValueError: If a supplied graph URI is not a valid IRI.
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         transaction = self.conn.transaction
@@ -1019,7 +1019,7 @@ class ICV:
         Examples:
           >>> icv.convert(File('constraints.ttl'), graph_uri='urn:graph')
 
-    :raises ValueError: If a supplied graph URI is not a valid IRI.
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
         validate_iri(graph_uri)
         with content.data() as data:
@@ -1053,7 +1053,7 @@ class ICV:
         Examples:
           >>> icv.report()
 
-    :raises ValueError: If a supplied graph URI is not a valid IRI.
+        :raises ValueError: If a supplied graph URI is not a valid IRI.
         """
 
         accepted_args = [

--- a/stardog/utils.py
+++ b/stardog/utils.py
@@ -13,6 +13,15 @@ def validate_iri(iri: Optional[str]) -> None:
     """
     if iri is None:
         return
+    if not isinstance(iri, str):
+        # A sequence used to reach the server untouched. These parameters are
+        # typed Optional[str]; where this API accepts several graphs it says
+        # so, as using_graph_uri does. Rejecting here keeps the failure a
+        # ValueError like every other bad graph URI, rather than a TypeError
+        # out of re.fullmatch.
+        raise ValueError(
+            f"graph URI must be a string, got {type(iri).__name__}: {iri!r}"
+        )
     if not _IRI.fullmatch(iri):
         raise ValueError(f"not a valid IRI: {iri!r}")
 

--- a/stardog/utils.py
+++ b/stardog/utils.py
@@ -1,9 +1,12 @@
 import re
 from typing import Optional
 
-# An absolute IRI: a scheme (no delimiters, no '/'), then ':', then anything
-# except the RFC 3987 delimiters and control characters (U+0000-U+0020).
-_IRI = re.compile(r"""[^\x00-\x20<>"{}|^`\\/:]+:[^\x00-\x20<>"{}|^`\\]*""")
+# An absolute IRI: an RFC 3986 scheme -- ALPHA *( ALPHA / DIGIT / "+" / "-" /
+# "." ) -- then ':', then a non-empty remainder free of the RFC 3987
+# delimiters and control characters (U+0000-U+0020). The scheme was
+# previously "anything without a delimiter", which accepted '?:x', '1abc:x',
+# 'a?b:c' and 'graph#a:b'; the remainder was optional, which accepted 'urn:'.
+_IRI = re.compile(r"""[A-Za-z][A-Za-z0-9+.\-]*:[^\x00-\x20<>"{}|^`\\]+""")
 
 
 def validate_iri(iri: Optional[str]) -> None:

--- a/stardog/utils.py
+++ b/stardog/utils.py
@@ -1,3 +1,22 @@
+import re
+from typing import Optional
+
+# An absolute IRI: a scheme (no delimiters, no '/'), then ':', then anything
+# except the RFC 3987 delimiters and control characters (U+0000-U+0020).
+_IRI = re.compile(r"""[^\x00-\x20<>"{}|^`\\/:]+:[^\x00-\x20<>"{}|^`\\]*""")
+
+
+def validate_iri(iri: Optional[str]) -> None:
+    """Raises ``ValueError`` unless ``iri`` is a valid absolute IRI.
+
+    ``None`` is accepted: it means no graph URI was given, i.e. the default graph.
+    """
+    if iri is None:
+        return
+    if not _IRI.fullmatch(iri):
+        raise ValueError(f"not a valid IRI: {iri!r}")
+
+
 def strtobool(s):
     truthy_values = ["y", "yes", "t", "true", "True", "on", 1]
     falsy_values = ["n", "no", "f", "false", "False", "off", 0]

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -682,3 +682,37 @@ class TestVirtualGraphUpdate:
             body = self._last_put(m)
 
         assert "mappings.syntax" not in body["options"]
+
+
+class TestGraphUriValidationReachesTheAPI:
+    """test_utils.py covers validate_iri directly. These assert that the
+    methods actually call it, one per family, so a call site removed by a
+    later refactor is caught rather than silently unvalidated."""
+
+    def _conn(self):
+        conn = connection.Connection("test")
+        conn.transaction = "tx-1"
+        return conn
+
+    def test_clear_rejects_a_bad_graph_uri(self):
+        with pytest.raises(ValueError):
+            self._conn().clear("not an iri")
+
+    def test_is_consistent_rejects_a_bad_graph_uri(self):
+        with pytest.raises(ValueError):
+            self._conn().is_consistent("not an iri")
+
+    def test_update_rejects_a_bad_insert_graph_uri(self):
+        with pytest.raises(ValueError):
+            self._conn().update("INSERT DATA {}", insert_graph_uri="not an iri")
+
+    def test_icv_report_rejects_a_bad_graph_uri(self):
+        icv = connection.ICV(self._conn())
+        with pytest.raises(ValueError):
+            icv.report(**{"graph-uri": "not an iri"})
+
+    def test_icv_report_rejects_bad_shacl_parameters(self):
+        icv = connection.ICV(self._conn())
+        for name in ("shapes", "shacl.shape.graphs", "nodes"):
+            with pytest.raises(ValueError):
+                icv.report(**{name: "not an iri"})

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -17,6 +17,18 @@ def test_graph_uri_validation_accepts(iri):
     validate_iri(iri)
 
 
+@pytest.mark.parametrize("value", [["urn:a", "urn:b"], 7, ("urn:a",), object()])
+def test_graph_uri_validation_rejects_non_strings(value):
+    """A list used to reach the server untouched, because __query forwarded
+    kwargs to requests without inspecting them. insert_graph_uri and
+    remove_graph_uri are typed Optional[str] -- where this API does take a
+    list it says so, as using_graph_uri does -- so a list was never
+    supported. It should still fail as a ValueError like every other bad
+    graph URI, not as a TypeError from re.fullmatch."""
+    with pytest.raises(ValueError):
+        validate_iri(value)
+
+
 def test_content():
 
     r = content.Raw("content", content_types.TURTLE, "zip", "raw.ttl.zip")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,14 +5,33 @@ from stardog.utils import validate_iri
 
 
 @pytest.mark.parametrize(
-    "iri", ["<urn:graph>", "urn:graph>", "urn: graph", "urn:gra\nph", "graph", ""]
+    "iri",
+    [
+        "<urn:graph>",
+        "urn:graph>",
+        "urn: graph",
+        "urn:gra\nph",
+        "graph",
+        "",
+        # RFC 3986 scheme is ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ).
+        # The first regex allowed anything without a delimiter, so all of
+        # these were accepted.
+        "?:x",
+        "1abc:x",
+        "a?b:c",
+        "graph#a:b",
+        "urn:",
+    ],
 )
 def test_graph_uri_validation_rejects(iri):
     with pytest.raises(ValueError):
         validate_iri(iri)
 
 
-@pytest.mark.parametrize("iri", ["urn:graph", "http://example.com/g", None])
+@pytest.mark.parametrize(
+    "iri",
+    ["urn:graph", "http://example.com/g", "a+b-c.d:x", "S3://bucket/k", None],
+)
 def test_graph_uri_validation_accepts(iri):
     validate_iri(iri)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,20 @@
+import pytest
+
 from stardog import content, content_types
+from stardog.utils import validate_iri
+
+
+@pytest.mark.parametrize(
+    "iri", ["<urn:graph>", "urn:graph>", "urn: graph", "urn:gra\nph", "graph", ""]
+)
+def test_graph_uri_validation_rejects(iri):
+    with pytest.raises(ValueError):
+        validate_iri(iri)
+
+
+@pytest.mark.parametrize("iri", ["urn:graph", "http://example.com/g", None])
+def test_graph_uri_validation_accepts(iri):
+    validate_iri(iri)
 
 
 def test_content():


### PR DESCRIPTION
Opened automatically by claude-auto from PLAT-8477. No human wrote this change
and no human has reviewed it.

https://stardog.atlassian.net/browse/PLAT-8477

## Triage rationale

Scoped to pystardog: the summary, the component, and the reproducer are all client-side, and the graph name reaches the server as the `graph-uri` query parameter set by `Connection.add` (stardog/connection.py:172), which today passes any string through unchecked. The fix is a small client-side guard — a single `validate_iri`-style helper in `stardog/utils.py` that rejects strings containing the characters the N-Triples/SPARQL IRIREF grammar forbids (`<`, `>`, `"`, `{`, `}`, `|`, `^`, backtick, backslash, whitespace and control characters) plus empty/relative-only values, raising `ValueError` the way `utils.strtobool` already does — called from the `Connection` methods that take a graph URI, so the sibling paths (`remove`, `clear`, `export`, `is_consistent`, `explain_inconsistency`, the ICV methods, and the `default/named/using/insert/remove-graph-uri` query params built in `_get_query_params`) are fixed at the same time rather than leaving `add` as the only strict entry point. Two things a human should note. First, this is a behaviour change in a public API: anyone currently passing `'<urn:graph>'` and getting a graph with angle brackets in its name will start getting a `ValueError`, and any such graphs already in a database are unaffected — the guard only prevents new ones, so cleanup of existing bad graph names is out of scope here. Second, the ticket's own closing note is correct and deliberately not addressed: the server accepts the same payload from curl or any other HTTP client, so validating in pystardog does not close the hole. That needs a separate ticket against the stardog repo for the transaction `add` endpoint; I have not attempted it here because it is a different codebase, a different (server-side) design question about which error code and status to return, and the linked Slack discussion is not readable from the issue. Validation rule chosen is the IRIREF character-exclusion set rather than full RFC 3987 conformance, since that is what the reported case (`<`/`>`) needs and full RFC 3987 validation would reject IRIs Stardog itself accepts.

## Plan followed

1. Add a module-level helper to stardog/utils.py, e.g. `validate_iri(iri: Optional[str]) -> None`, that returns immediately for None (no graph URI means the default graph), and otherwise raises `ValueError` with a message naming the offending value when the string is empty, contains any of `<`, `>`, `"`, `{`, `}`, `|`, `^`, `` ` ``, `\`, whitespace, or a control character (U+0000-U+0020), or has no scheme (no `:` before the first `/`). Implement as one compiled regex plus a scheme check; do not add a dependency and do not use rdflib's private `_is_valid_uri`.
2. In stardog/connection.py, import the helper and call it on the graph URI argument at the start of `Connection.add`, `Connection.remove`, `Connection.clear`, `Connection.export`, `Connection.is_consistent`, and `Connection.explain_inconsistency`, and on the ICV methods `is_valid`, `explain_violations`, and `convert`.
3. In `_get_query_params` (stardog/connection.py:331-336), validate the graph URI kwargs too: call the helper on each element of the list-valued `default_graph_uri`, `named_graph_uri`, `using_graph_uri`, `using_named_graph_uri`, and on the scalar `remove_graph_uri` and `insert_graph_uri`.
4. Add a server-free unit test `test_graph_uri_validation` to test/test_utils.py: assert `pytest.raises(ValueError)` for `'<urn:graph>'`, `'urn:graph>'`, `'urn: graph'`, and `''`, and assert no raise for `'urn:graph'`, `'http://example.com/g'`, and `None`. Keep it in test_utils.py so it runs without a Stardog instance (test_connection.py needs a live server).
5. Update the `graph_uri` docstrings in `Connection.add` and `Connection.remove` to state that an invalid IRI raises `ValueError`, and run `black` (line-length 88, configured in pyproject.toml) over the touched files.

## Verification performed

- Tier 0 static checks: passed (3 files, 62 added lines)
- Tier 1 compile: passed
- Tier 2 targeted tests: passed (graph_uri_validation)
- Tier 3 CI on this pull request: not run locally; it is the real correctness gate

---

This is a **draft** pull request written by an agent and has not been reviewed
by a human. Verification above is what ran locally; it is not a guarantee of
correctness. CI on this pull request is the real gate.
